### PR TITLE
Uber Standard uninitialized constant issue

### DIFF
--- a/src/lint/linter/UberStandardLinter.php
+++ b/src/lint/linter/UberStandardLinter.php
@@ -76,7 +76,7 @@ final class UberStandardLinter extends ArcanistExternalLinter {
   public function setLinterConfigurationValue($key, $value) {
     switch ($key) {
       case 'uber-standard.eslintrc':
-        $this->lintrc = $value;
+        $this->eslintrc = $value;
         return;
     }
 


### PR DESCRIPTION
This PR fixes an uninitialized constant issue with uber standard. I honestly have no idea how this got broken because this used to work. 

cc: @sectioneight 