### PR TITLE
Move 'sirmixalot' logic to our own ArcanistLandWorkflow.php to make e…

### DIFF
--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -169,6 +169,16 @@ final class ArcanistSettings extends Phobject {
         'default' => false,
         'example' => 'false',
       ),
+      'uber.sirmixalot.enrolled' => array(
+        'type' => 'bool',
+        'help' => pht(
+          'If true, the setting will enable sirmixalot enrollment for this '.
+          'repo. This means that the merged commit produced while landing a '.
+          'diff will be put to `%s` branch instead of the master branch.',
+          'landed/TIMESTAMP'),
+        'default' => false,
+        'example' => 'true',
+      ),
     );
   }
 

--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -1029,17 +1029,12 @@ EOTEXT
         $this->onto)."\n");
     } else {
       $sirmixalot_enrolled = $this->getConfigFromAnySource(
-        'sirmixalot.enrolled',
+        'uber.sirmixalot.enrolled',
         false);
-      // check if repo is enrolled to sirmixalot
+      // check, if this repo is enrolled to sirmixalot service
       if ($sirmixalot_enrolled) {
         // if repo is enrolled, land change on a specific remote branch
-        $sirmixalot_remote_landed_branch_templ = $this->getConfigFromAnySource(
-          'sirmixalot.remote_landed_branch_template',
-          'landed/%s');
-        $remote_landed_branch = sprintf(
-          $sirmixalot_remote_landed_branch_templ,
-          date("YmdHis"));
+        $remote_landed_branch = sprintf('landed/%s', date("YmdHis"));
         $landed_branch = sprintf("HEAD:%s", $remote_landed_branch);
       } else {
         $remote_landed_branch = $landed_branch = $this->onto;


### PR DESCRIPTION
Currently 'sirmixalot' functionality exists as a plugin and requires additional files in each repo as well as `.arcconfig` changes to get repos enrolled.

Since we forked 'arcanist', the implementation can be made nicer and simpler by just modifying `ArcanistLandWorkflow.php` file.

Looking forward to any feedback and willing to make changes as needed - PHP is not my primary language.

Original changes (using the plugin system) can be seen in arcanist_playground repo.