### PR TITLE
Use goimports for gofmt if available

### DIFF
--- a/src/lint/linter/ArcanistGoFmtLinter.php
+++ b/src/lint/linter/ArcanistGoFmtLinter.php
@@ -27,7 +27,15 @@ final class ArcanistGoFmtLinter extends ArcanistLinter {
   }
 
   public function getBinary() {
+    $go_imports = $this->getGoImportsBinary();
+    if (Filesystem::binaryExists($go_imports)) {
+      return $go_imports;
+    }
     return 'gofmt';
+  }
+
+  public function getGoImportsBinary() {
+    return 'goimports';
   }
 
   protected function checkBinaryConfiguration() {


### PR DESCRIPTION
Goimports is gofmt in steroids; automatically adding and removing imports for
you. It is API-compatible with gofmt, but better.