### PR TITLE
Fix Go Vet linter

### DIFF
--- a/src/lint/linter/ArcanistGoVetLinter.php
+++ b/src/lint/linter/ArcanistGoVetLinter.php
@@ -80,6 +80,7 @@ final class ArcanistGoVetLinter extends ArcanistExternalLinter {
         $message->setPath($path);
         $message->setLine($matches[1]);
         $message->setCode($this->getLinterName());
+        $message->setName($this->getLinterName());
         $message->setDescription(ucfirst(trim($matches[2])));
         $message->setSeverity(ArcanistLintSeverity::SEVERITY_WARNING);
 


### PR DESCRIPTION
Previously:

    Linting...
    Exception
    Linter "ArcanistGoVetLinter" generated a lint message that is invalid
    because it does not have a name. Lint messages must have a name.
    (Run with `--trace` for a full exception trace.)

Set name to the linter name, like the gofmt linter.