### PR TITLE
Avoid erring while using uber-standard due to missing name key

### DIFF
--- a/src/lint/linter/UberStandardLinter.php
+++ b/src/lint/linter/UberStandardLinter.php
@@ -109,6 +109,7 @@ final class UberStandardLinter extends ArcanistExternalLinter {
         $message->setLine(idx($err, 'line'));
         $message->setChar(idx($err, 'column'));
         $message->setCode(idx($err, 'rule'));
+        $message->setName(idx($err, 'message'));
         $message->setDescription(idx($err, 'message'));
         $message->setSeverity($this->getLintMessageSeverity(idx($err, 'type')));
 


### PR DESCRIPTION
Name was added as a requirement to `ArcanistLintMessage` in https://secure.phabricator.com/D14165

I was getting this error:

```
[2016-05-12 23:13:10] EXCEPTION: (Exception) Linter "UberStandardLinter" generated a lint message that is invalid because it does not have a name. Lint messages must have a name. at [<arcanist>/src/lint/engine/ArcanistLintEngine.php:609]
arcanist(head=master, ref.master=2b9287eb53a4), phutil(head=master, ref.master=84b0feab4220)
  #0 ArcanistLintEngine::validateLintMessage(UberStandardLinter, ArcanistLintMessage) called at [<arcanist>/src/lint/engine/ArcanistLintEngine.php:220]
  #1 ArcanistLintEngine::run() called at [<arcanist>/src/workflow/ArcanistLintWorkflow.php:334]
  #2 ArcanistLintWorkflow::run() called at [<arcanist>/scripts/arcanist.php:392]
```