### PR TITLE
Verify that the mandatory fields (testPlan, revertPlan)  are non empty when doing arc diff.

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -1860,23 +1860,25 @@ EOTEXT
     $mandatory_fields = $config->getConfigFromAnySource(
       'differential.mandatory_fields');
 
-    if (in_array('testPlan', $mandatory_fields)) {
-      $test_plan = $message->getFieldValue('testPlan');
-      if (empty($test_plan)) {
-        throw new ArcanistUsageException(
-          pht(
-            'You have not specified any test plan. '.
-            'Specify test plan and retry.'));
+    if (!is_null($mandatory_fields)) {
+      if (in_array('testPlan', $mandatory_fields)) {
+        $test_plan = $message->getFieldValue('testPlan');
+        if (empty($test_plan)) {
+          throw new ArcanistUsageException(
+            pht(
+              'You have not specified any test plan. '.
+              'Specify test plan and retry.'));
+        }
       }
-    }
 
-    if (in_array('revertPlan', $mandatory_fields)) {
-      $revert_plan = $message->getFieldValue('revertPlan');
-      if (empty($revert_plan)) {
-        throw new ArcanistUsageException(
-          pht(
-            'You have not specified any revert plan. '.
-            'Specify revert plan and retry.'));
+      if (in_array('revertPlan', $mandatory_fields)) {
+        $revert_plan = $message->getFieldValue('revertPlan');
+        if (empty($revert_plan)) {
+          throw new ArcanistUsageException(
+            pht(
+              'You have not specified any revert plan. '.
+              'Specify revert plan and retry.'));
+        }
       }
     }
   }

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -1861,23 +1861,13 @@ EOTEXT
       'differential.mandatory_fields');
 
     if (!is_null($mandatory_fields)) {
-      if (in_array('testPlan', $mandatory_fields)) {
-        $test_plan = $message->getFieldValue('testPlan');
-        if (empty($test_plan)) {
+      foreach ($mandatory_fields as $mandatory_field){
+        $fieldName = $mandatory_field['field_name'];
+        $field = $message->getFieldValue($fieldName);
+        if (empty($field)) {
+          $fieldMessage = $mandatory_field['field_message'];
           throw new ArcanistUsageException(
-            pht(
-              'You have not specified any test plan. '.
-              'Specify test plan and retry.'));
-        }
-      }
-
-      if (in_array('revertPlan', $mandatory_fields)) {
-        $revert_plan = $message->getFieldValue('revertPlan');
-        if (empty($revert_plan)) {
-          throw new ArcanistUsageException(
-            pht(
-              'You have not specified any revert plan. '.
-              'Specify revert plan and retry.'));
+            pht($fieldMessage));
         }
       }
     }

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -1856,6 +1856,29 @@ EOTEXT
       }
     }
 
+    $config = $this->getConfigurationManager();
+    $mandatory_fields = $config->getConfigFromAnySource(
+      'differential.mandatory_fields');
+
+    if (in_array('testPlan', $mandatory_fields)) {
+      $test_plan = $message->getFieldValue('testPlan');
+      if (empty($test_plan)) {
+        throw new ArcanistUsageException(
+          pht(
+            'You have not specified any test plan. '.
+            'Specify test plan and retry.'));
+      }
+    }
+
+    if (in_array('revertPlan', $mandatory_fields)) {
+      $revert_plan = $message->getFieldValue('revertPlan');
+      if (empty($revert_plan)) {
+        throw new ArcanistUsageException(
+          pht(
+            'You have not specified any revert plan. '.
+            'Specify revert plan and retry.'));
+      }
+    }
   }
 
 


### PR DESCRIPTION
- specify mandatory field in .arcconfig as  `"differential.mandatory_fields": ["testPlan", "revertPlan"]`
- Throws an exception if not specified and exits the workflow.
