### PR TITLE
Make ArcanistGoLintLinter great again

### DIFF
--- a/src/lint/linter/ArcanistGoLintLinter.php
+++ b/src/lint/linter/ArcanistGoLintLinter.php
@@ -55,7 +55,7 @@ final class ArcanistGoLintLinter extends ArcanistExternalLinter {
         $message->setCode($this->getLinterName());
         $message->setName($this->getLinterName());
         $message->setDescription(ucfirst(trim($matches[3])));
-        $message->setSeverity(ArcanistLintSeverity::SEVERITY_ADVICE);
+        $message->setSeverity(ArcanistLintSeverity::SEVERITY_WARNING);
 
         $messages[] = $message;
       }

--- a/src/lint/linter/ArcanistGoLintLinter.php
+++ b/src/lint/linter/ArcanistGoLintLinter.php
@@ -55,7 +55,7 @@ final class ArcanistGoLintLinter extends ArcanistExternalLinter {
         $message->setCode($this->getLinterName());
         $message->setName($this->getLinterName());
         $message->setDescription(ucfirst(trim($matches[3])));
-        $message->setSeverity($this->getLintMessageSeverity($this->getLinterName()));
+        $message->setSeverity($this->getLintMessageSeverity($message->getCode()));
 
         $messages[] = $message;
       }

--- a/src/lint/linter/ArcanistGoLintLinter.php
+++ b/src/lint/linter/ArcanistGoLintLinter.php
@@ -55,7 +55,7 @@ final class ArcanistGoLintLinter extends ArcanistExternalLinter {
         $message->setCode($this->getLinterName());
         $message->setName($this->getLinterName());
         $message->setDescription(ucfirst(trim($matches[3])));
-        $message->setSeverity(ArcanistLintSeverity::SEVERITY_WARNING);
+        $message->setSeverity($this->getLintMessageSeverity($this->getLinterName()));
 
         $messages[] = $message;
       }


### PR DESCRIPTION
The linter currently ignores `severity.rules` and `severity` settings, categorizing everything as advice. This means that `arc lint` reports success regardless of the output of `golint`.

This fixes the linter to default these to errors and to respect the contents of `severity.rules`/`severity`.

Tested and confirmed locally.

@Pawka @prashantv 