### PR TITLE
Make the objc style check lint repo path relative to the project root

### DIFF
--- a/src/lint/linter/UberObjCStyleCheckLinter.php
+++ b/src/lint/linter/UberObjCStyleCheckLinter.php
@@ -36,7 +36,7 @@ final class UberObjCStyleCheckLinter extends ArcanistExternalLinter {
   }
 
   public function setLintRepoPath($path) {
-    $this->lintRepoPath = $path;
+    $this->lintRepoPath = $this->getProjectRoot().'/'.$path;
     return $this;
   }
 


### PR DESCRIPTION
This makes it possible to specify a custom lint repo path relative to the project, otherwise it would need to be absolute and therefore different for each user.