### PR TITLE
Use a regex to handle go vet better

### DIFF
--- a/src/lint/linter/ArcanistGoVetLinter.php
+++ b/src/lint/linter/ArcanistGoVetLinter.php
@@ -73,15 +73,15 @@ final class ArcanistGoVetLinter extends ArcanistExternalLinter {
 
     $messages = array();
     foreach ($lines as $line) {
-      $matches = explode(':', $line, 3);
+      preg_match('/[^:]*:([0-9]+)(:[0-9]+)?: (.*)/', $line, $matches);
 
-      if (count($matches) === 3) {
+      if (count($matches) === 4) {
         $message = new ArcanistLintMessage();
         $message->setPath($path);
         $message->setLine($matches[1]);
         $message->setCode($this->getLinterName());
         $message->setName($this->getLinterName());
-        $message->setDescription(ucfirst(trim($matches[2])));
+        $message->setDescription(ucfirst(trim($matches[3])));
         $message->setSeverity(ArcanistLintSeverity::SEVERITY_WARNING);
 
         $messages[] = $message;


### PR DESCRIPTION
Previously, if "go vet" failed to parse the input, since the output
format is different we'd call setLine() with something that's not a number.