### PR TITLE
Enable shadow mode for SubmitQueue.

### DIFF
--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -201,6 +201,16 @@ final class ArcanistSettings extends Phobject {
         'help' => pht('URI to use for the submitqueue backend'),
         'example' => '"https://submitqueue.uberinternal.com"',
       ),
+      'uber.land.submitqueue.shadow' => array(
+        'type' => 'bool',
+        'help' => pht(
+          'If true, `arc land` will submit requests to submitqueue with'.
+          'shadow_option=true, and on success land the request using the '.
+          'arcanist gitland engine'
+        ),
+        'default' => false,
+        'example' => 'false',
+      ),
     );
   }
 

--- a/src/land/UberArcanistSubmitQueueEngine.php
+++ b/src/land/UberArcanistSubmitQueueEngine.php
@@ -4,6 +4,7 @@ final class UberArcanistSubmitQueueEngine
     extends ArcanistGitLandEngine
 {
   private $revision;
+  private $shouldShadow;
 
   public function execute() {
     $this->verifySourceAndTargetExist();
@@ -25,15 +26,20 @@ final class UberArcanistSubmitQueueEngine
       $this->updateRevision();
 
       $this->pushChange();
-      $this->reconcileLocalState();
-
-      if ($this->getShouldKeep()) {
-        echo tsprintf(
-        "%s\n",
-        pht('Keeping local branch.'));
+      if ($this->shouldShadow) {
+        // do nothing
       } else {
-        $this->checkoutTarget();
-        $this->destroyLocalBranch();
+        // cleanup the local state
+        $this->reconcileLocalState();
+
+        if ($this->getShouldKeep()) {
+          echo tsprintf(
+            "%s\n",
+            pht('Keeping local branch.'));
+        } else {
+          $this->checkoutTarget();
+          $this->destroyLocalBranch();
+        }
       }
       $this->restoreWhenDestroyed = false;
     }  catch (Exception $ex) {
@@ -100,6 +106,11 @@ final class UberArcanistSubmitQueueEngine
 
   final public function getRevision() {
     return $this->revision;
+  }
+
+  final public function setShouldShadow($shouldShadow) {
+    $this->shouldShadow = $shouldShadow;
+    return $this;
   }
 
   final public function setRevision($revision) {

--- a/src/land/UberArcanistSubmitQueueEngine.php
+++ b/src/land/UberArcanistSubmitQueueEngine.php
@@ -69,7 +69,8 @@ final class UberArcanistSubmitQueueEngine
     $statusUrl = $this->submitQueueClient->submitMergeRequest(
       $remoteUrl,
       $revision['diffs'][0],
-      $revision['id']);
+      $revision['id'],
+      $this->shouldShadow);
     $this->writeInfo(
       pht('Successfully submitted the request to the Submit Queue.'),
       pht('Please use "%s" to track your changes', $statusUrl));

--- a/src/land/UberSubmitQueueClient.php
+++ b/src/land/UberSubmitQueueClient.php
@@ -4,15 +4,17 @@ final class UberSubmitQueueClient extends Phobject {
 
     private $uri;
     private $host;
+    private $conduit_token;
     private $timeout;
 
-    public function __construct($uri, $timeout=10) {
+    public function __construct($uri, $conduit_token, $timeout=10) {
         $this->uri = new PhutilURI($uri);
         if (!strlen($this->uri->getDomain())) {
             throw new Exception(
                 pht("SubmitQueue URI '%s' must include a valid host.", $uri));
         }
         $this->host = $this->uri->getDomain();
+        $this->conduit_token = $conduit_token;
         $this->timeout = $timeout;
     }
 
@@ -25,6 +27,7 @@ final class UberSubmitQueueClient extends Phobject {
           'remote' => $remoteUrl,
           'diffId' => $diffId,
           'revisionId' => $revisionId,
+          'conduitToken' => $this->conduit_token,
         );
         if ($shouldShadow) {
           $params['shouldShadow'] = "true";

--- a/src/land/UberSubmitQueueClient.php
+++ b/src/land/UberSubmitQueueClient.php
@@ -27,7 +27,7 @@ final class UberSubmitQueueClient extends Phobject {
           'revisionId' => $revisionId,
         );
         if ($shouldShadow) {
-          $params['shouldShadow'] = true;
+          $params['shouldShadow'] = "true";
         }
         return $this->callMethodSynchronous("POST", "/merge_requests", $params);
     }

--- a/src/land/UberSubmitQueueClient.php
+++ b/src/land/UberSubmitQueueClient.php
@@ -4,17 +4,17 @@ final class UberSubmitQueueClient extends Phobject {
 
     private $uri;
     private $host;
-    private $conduit_token;
+    private $conduitToken;
     private $timeout;
 
-    public function __construct($uri, $conduit_token, $timeout=10) {
+    public function __construct($uri, $conduitToken, $timeout=10) {
         $this->uri = new PhutilURI($uri);
         if (!strlen($this->uri->getDomain())) {
             throw new Exception(
                 pht("SubmitQueue URI '%s' must include a valid host.", $uri));
         }
         $this->host = $this->uri->getDomain();
-        $this->conduit_token = $conduit_token;
+        $this->conduitToken = $conduitToken;
         $this->timeout = $timeout;
     }
 
@@ -27,7 +27,7 @@ final class UberSubmitQueueClient extends Phobject {
           'remote' => $remoteUrl,
           'diffId' => $diffId,
           'revisionId' => $revisionId,
-          'conduitToken' => $this->conduit_token,
+          'conduitToken' => $this->conduitToken,
         );
         if ($shouldShadow) {
           $params['shouldShadow'] = "true";

--- a/src/land/UberSubmitQueueClient.php
+++ b/src/land/UberSubmitQueueClient.php
@@ -20,14 +20,16 @@ final class UberSubmitQueueClient extends Phobject {
         return $this->host;
     }
 
-    public function submitMergeRequest($remoteUrl, $diffId, $revisionId) {
+    public function submitMergeRequest($remoteUrl, $diffId, $revisionId, $shouldShadow) {
         $params = array(
           'remote' => $remoteUrl,
           'diffId' => $diffId,
           'revisionId' => $revisionId,
         );
-        $result = $this->callMethodSynchronous("POST", "/merge_requests", $params);
-        return "whatever";
+        if ($shouldShadow) {
+          $params['shouldShadow'] = true;
+        }
+        return $this->callMethodSynchronous("POST", "/merge_requests", $params);
     }
 
     private function callMethodSynchronous($method, $api, array $params) {

--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -628,7 +628,10 @@ EOTEXT
             "You are trying to use submitqueue, but the submitqueue URI for your repo is not set");
         throw new ArcanistUsageException($message);
       }
-      $this->submitQueueClient = new UberSubmitQueueClient($this->submitQueueUri);
+      $this->submitQueueClient =
+        new UberSubmitQueueClient(
+          $this->submitQueueUri,
+          $this->getConduit()->getConduitToken());
     }
   }
 

--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -23,6 +23,7 @@ final class ArcanistLandWorkflow extends ArcanistWorkflow {
   private $preview;
   private $shouldUseSubmitQueue;
   private $submitQueueUri;
+  private $submitQueueShadowMode;
   private $submitQueueClient;
   private $tbr;
 
@@ -267,12 +268,20 @@ EOTEXT
     $this->readArguments();
 
     $engine = null;
+    $uberShadowEngine = null;
     if ($this->isGit && !$this->isGitSvn) {
       $engine = new ArcanistGitLandEngine();
       if ($this->shouldUseSubmitQueue && !$this->tbr) {
-        $engine = new UberArcanistSubmitQueueEngine(
-          $this->submitQueueClient,
-          $this->getConduit());
+        // If the shadow-mode is on, then initialize the shadowEngine
+        if ($this->submitQueueShadowMode) {
+          $uberShadowEngine = new UberArcanistSubmitQueueEngine(
+            $this->submitQueueClient,
+            $this->getConduit());
+        } else {
+          $engine = new UberArcanistSubmitQueueEngine(
+            $this->submitQueueClient,
+            $this->getConduit());
+        }
       }
     }
 
@@ -309,6 +318,24 @@ EOTEXT
         ->setShouldSquash($this->useSquash)
         ->setShouldPreview($this->preview)
         ->setBuildMessageCallback(array($this, 'buildEngineMessage'));
+
+      // initialize the shadow engine and execute it if uberShadowEngine is initialized
+      if ($uberShadowEngine) {
+        $uberShadowEngine
+          ->setWorkflow($this)
+          ->setRepositoryAPI($this->getRepositoryAPI())
+          ->setSourceRef($this->branch)
+          ->setTargetRemote($this->remote)
+          ->setTargetOnto($this->onto)
+          ->setShouldHold($should_hold)
+          ->setShouldKeep($this->keepBranch)
+          ->setShouldSquash($this->useSquash)
+          ->setShouldPreview($this->preview)
+          ->setBuildMessageCallback(array($this, 'buildEngineMessage'))
+          ->setRevision($this->uberGetRevision())
+          ->setShouldShadow(true);
+        $uberShadowEngine->execute();
+      }
 
       if ($engine instanceof UberArcanistSubmitQueueEngine) {
         $engine->setRevision($this->uberGetRevision());
@@ -595,6 +622,7 @@ EOTEXT
     }
     if ($this->shouldUseSubmitQueue) {
       $this->submitQueueUri = $this->getConfigFromAnySource('uber.land.submitqueue.uri');
+      $this->submitQueueShadowMode = $this->getConfigFromAnySource('uber.land.submitqueue.shadow');
       if(empty($this->submitQueueUri)) {
         $message = pht(
             "You are trying to use submitqueue, but the submitqueue URI for your repo is not set");


### PR DESCRIPTION
 The idea is to be able to send merge-requests to submitqueue, but still follow the original land pattern.

Context: We need to make sure SQ can handle the load etc.. for a given repository. And we want to do this in the most harmless fashion. The route we were able to think about was -> send merge_request metadata to SQ (which will handle the merge for the **shadow repo**), continue with the original land request. In order to achieve this, I have added an option that says 'enable_shadow'. if the shadow mode is on, then a secondary engine is created, and executed. The original engine is executed after the above is done.