### PR TITLE
SQ Bug fixes

### DIFF
--- a/src/land/UberArcanistSubmitQueueEngine.php
+++ b/src/land/UberArcanistSubmitQueueEngine.php
@@ -74,9 +74,6 @@ final class UberArcanistSubmitQueueEngine
     $this->writeInfo(
       pht('Successfully submitted the request to the Submit Queue.'),
       pht('Please use "%s" to track your changes', $statusUrl));
-     $this->writeInfo(
-       pht('If the Submit Queue request fails,'),
-       pht('please do arc restore "%s" to restore your branch', 'whatever'));
   }
 
   public function __construct($submitQueueClient, $conduit) {

--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -844,73 +844,8 @@ EOTEXT
   // reason it has been copied as a separate function is that this way it
   // is easier to maintain with the upstream changes
   public function uberGetRevision() {
-    $repository_api = $this->getRepositoryAPI();
-
-    $this->parseBaseCommitArgument(array($this->ontoRemoteBranch));
-
-    $revision_id = $this->getArgument('revision');
-    if ($revision_id) {
-      $revision_id = $this->normalizeRevisionID($revision_id);
-      $revisions = $this->getConduit()->callMethodSynchronous(
-        'differential.query',
-        array(
-          'ids' => array($revision_id),
-        ));
-      if (!$revisions) {
-        throw new ArcanistUsageException(pht(
-          "No such revision '%s'!",
-          "D{$revision_id}"));
-      }
-    } else {
-      $revisions = $repository_api->loadWorkingCopyDifferentialRevisions(
-        $this->getConduit(),
-        array());
-    }
-
-    if (!count($revisions)) {
-      throw new ArcanistUsageException(pht(
-        "arc can not identify which revision exists on %s '%s'. Update the ".
-        "revision with recent changes to synchronize the %s name and hashes, ".
-        "or use '%s' to amend the commit message at HEAD, or use ".
-        "'%s' to select a revision explicitly.",
-        $this->branchType,
-        $this->branch,
-        $this->branchType,
-        'arc amend',
-        '--revision <id>'));
-    } else if (count($revisions) > 1) {
-      switch ($this->branchType) {
-        case self::REFTYPE_BOOKMARK:
-          $message = pht(
-            "There are multiple revisions on feature bookmark '%s' which are ".
-            "not present on '%s':\n\n".
-            "%s\n".
-            'Separate these revisions onto different bookmarks, or use '.
-            '--revision <id> to use the commit message from <id> '.
-            'and land them all.',
-            $this->branch,
-            $this->onto,
-            $this->renderRevisionList($revisions));
-          break;
-        case self::REFTYPE_BRANCH:
-        default:
-          $message = pht(
-            "There are multiple revisions on feature branch '%s' which are ".
-            "not present on '%s':\n\n".
-            "%s\n".
-            'Separate these revisions onto different branches, or use '.
-            '--revision <id> to use the commit message from <id> '.
-            'and land them all.',
-            $this->branch,
-            $this->onto,
-            $this->renderRevisionList($revisions));
-          break;
-      }
-
-      throw new ArcanistUsageException($message);
-    }
-
-    return head($revisions);
+    $this->findRevision();
+    return $this->revision;
   }
 
   private function findRevision() {


### PR DESCRIPTION
1. Calling findRevision() now as part of uberGetRevision() as it has other
features like checking that the revision is up to date & checking to see if
harbormaster buildables have passed & reviewers have accepted the review etc..
2. Cleaning up SQ failover message
