### PR TITLE
Changing the way the uber-merge-strategy works

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -753,7 +753,7 @@ EOTEXT
         $ex = null;
         try {
           if ($this->shouldUseMerge()) {
-            $repository_api->execxLocal('merge %s', $new_branch);
+            $repository_api->execxLocal('cherry-pick --keep-redundant-commits %s', $new_branch);
           } else {
             $repository_api->execxLocal('cherry-pick %s', $new_branch);
           }


### PR DESCRIPTION
- What we want is the ability to cherry pick empty changes for SQ. 
- Initially we went with the merge strategy instead of cherry picking. But for release branches this is not ideal as you would end up picking up commits that are not in the release branch's history as they diverge a lot from the master branch.