### PR TITLE
Add config to change --no-verify in git push in arc diff.

### DIFF
--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -248,6 +248,14 @@ final class ArcanistSettings extends Phobject {
         'default' => array(),
         'example' => '["X, Y, Z"]',
       ),
+      'uber.diff.git.push.verify' => array(
+        'type' => 'bool',
+        'help' => pht(
+          'If true, `arc diff` will run `git push` with `--verify` flag, '.
+          'and if missing (or false), `arc diff` will run `git push` with '.
+          '`--no-verify` flag.'),
+        'default' => false,
+      ),
     );
   }
 

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -2755,8 +2755,15 @@ EOTEXT
       pht('Pushing changes to staging area...'));
 
     $push_flags = array();
+
+    $verify_config_name = 'uber.diff.git.push.verify';
+    $verify = $this->getConfigFromAnySource($verify_config_name);
     if (version_compare($api->getGitVersion(), '1.8.2', '>=')) {
-      $push_flags[] = '--no-verify';
+      if ($verify) {
+        $push_flags[] = '--verify'; // default in git
+      } else {
+        $push_flags[] = '--no-verify';
+      }
     }
 
     $refs = array();


### PR DESCRIPTION
ArcanistDiffWorkflow adds "--no-verify" flag to "git push" execution,
when code is pushed to staging area. This bypasses pre-push hook.

Git LFS uses pre-push hook to upload the files tracked by LFS to Git LFS
repo.

Make this configurable.