### PR TITLE
Replace staging uri with git remote name.

### DIFF
--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -256,6 +256,15 @@ final class ArcanistSettings extends Phobject {
           '`--no-verify` flag.'),
         'default' => false,
       ),
+      'uber.diff.staging.uri.replace' => array(
+        'type' => 'bool',
+        'help' => pht(
+          'If true, and staging environment is setup, then it will replace '.
+          'staging uri with git remote name defined for it. It parses '.
+          '"git remote -v" output and uses first remote name where remote url '.
+          'matches staging uri.'),
+        'default' => false,
+      ),
     );
   }
 


### PR DESCRIPTION
When staging area is setup, arc diff invokes "git push" with staging
URI. Same staging URI is passed to pre-push hook. For Git LFS, pre-push
hook invokes git rev-list by passing the same URI with "--remotes="
parameter, where rev-list does not work with URIs.

This PR, checks "git remote -v" output, and replaces staging URI with
remote name instead, if there is a git remote defined for given staging
URI.