### PR TITLE
Always use gofmt in gofmt linter

### DIFF
--- a/src/lint/linter/ArcanistGoFmtLinter.php
+++ b/src/lint/linter/ArcanistGoFmtLinter.php
@@ -27,15 +27,7 @@ final class ArcanistGoFmtLinter extends ArcanistLinter {
   }
 
   public function getBinary() {
-    $go_imports = $this->getGoImportsBinary();
-    if (Filesystem::binaryExists($go_imports)) {
-      return $go_imports;
-    }
     return 'gofmt';
-  }
-
-  public function getGoImportsBinary() {
-    return 'goimports';
   }
 
   protected function checkBinaryConfiguration() {


### PR DESCRIPTION
Goimports is doing weird things according to some coworkers, and
rewriting import order is a weird thing to do as part of a linter.
Changing this to be simpler.