### PR TITLE
Prevent developers from committing changes that are not committed

### DIFF
--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -193,6 +193,15 @@ final class ArcanistSettings extends Phobject {
         'default' => false,
         'example' => 'false',
       ),
+      'uber.land.prevent-unaccepted-changes' => array(
+        'type' => 'bool',
+        'help' => pht(
+          'If true, `%s` will prevent developers to land changes that'.
+          'are not accepted.',
+          'arc land'),
+        'default' => false,
+        'example' => 'false',
+      ),
       'uber.land.review-check' => array(
         'type' => 'bool',
         'help' => pht(

--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -1024,6 +1024,14 @@ EOTEXT
       }
     }
 
+    $uber_prevent_unaccepted_changes = $this->getConfigFromAnySource(
+      'uber.land.prevent-unaccepted-changes',
+      false);
+    if ($uber_prevent_unaccepted_changes && $rev_status != ArcanistDifferentialRevisionStatus::ACCEPTED) {
+      throw new ArcanistUsageException(
+        pht("Revision '%s' has not been accepted.", "D{$rev_id}: {$rev_title}"));
+    }
+
     if ($rev_status != ArcanistDifferentialRevisionStatus::ACCEPTED) {
       $ok = phutil_console_confirm(pht(
         "Revision '%s' has not been accepted. Continue anyway?",


### PR DESCRIPTION
The added flag when enabled prevents developers from committing code that is not accepted.