### PR TITLE
Use %{line} variable for puppet-lint log-format option

### DIFF
--- a/src/lint/linter/ArcanistPuppetLintLinter.php
+++ b/src/lint/linter/ArcanistPuppetLintLinter.php
@@ -56,7 +56,7 @@ final class ArcanistPuppetLintLinter extends ArcanistExternalLinter {
     return array(
       '--error-level=all',
       sprintf('--log-format=%s', implode('|', array(
-        '%{linenumber}',
+        '%{line}',
         '%{column}',
         '%{kind}',
         '%{check}',


### PR DESCRIPTION
%{linenumber} was deprecated long time ago and has been removed since puppet-lint 2.1.0