### PR TITLE
SubmitQueueEngine dispatches pre-push event if configured

### DIFF
--- a/src/land/UberArcanistSubmitQueueEngine.php
+++ b/src/land/UberArcanistSubmitQueueEngine.php
@@ -20,6 +20,13 @@ final class UberArcanistSubmitQueueEngine
       return;
     }
 
+    $workflow = $this->getWorkflow();
+    if ($workflow->getConfigFromAnySource("uber.land.submitqueue.events.prepush")) {
+      // fn dispatches ArcanistEventType::TYPE_LAND_WILLPUSHREVISION for
+      // arc-pre-push hooks;  see UberArcPrePushEventListener
+      $workflow->didCommitMerge();
+    }
+
     $this->saveLocalState();
 
     try {


### PR DESCRIPTION
we have some user interactive  hooks that depend on pre-push event (gather developer NPS, check/confirm breaking changes in IDL) .  the SubmitQueue engine does not currently emit these.  This to SubmitQueue will dispatch the event in the presence of a config value