### PR TITLE
Adding support for arc land branchname in SubmitQueue

### DIFF
--- a/src/land/ArcanistGitLandEngine.php
+++ b/src/land/ArcanistGitLandEngine.php
@@ -146,7 +146,7 @@ class ArcanistGitLandEngine
     }
   }
 
-  private function updateWorkingCopy() {
+  protected function updateWorkingCopy() {
     $api = $this->getRepositoryAPI();
     $source = $this->sourceCommit;
 
@@ -209,7 +209,7 @@ class ArcanistGitLandEngine
     $this->mergedRef = trim($stdout);
   }
 
-  private function pushChange() {
+  protected function pushChange() {
     $api = $this->getRepositoryAPI();
 
     $this->writeInfo(

--- a/src/land/UberArcanistSubmitQueueEngine.php
+++ b/src/land/UberArcanistSubmitQueueEngine.php
@@ -6,6 +6,9 @@ final class UberArcanistSubmitQueueEngine
   private $revision;
   private $shouldShadow;
   private $skipUpdateWorkingCopy;
+  private $submitQueueRegex;
+  private $tbr;
+  private $submitQueueTags;
 
   public function execute() {
     $this->verifySourceAndTargetExist();
@@ -30,12 +33,22 @@ final class UberArcanistSubmitQueueEngine
     $this->saveLocalState();
 
     try {
+      $this->identifyRevision();
+      print_r($this->revision);
+      assert(!empty($this->revision));
       if (!$this->getSkipUpdateWorkingCopy()) {
         $this->updateWorkingCopy();
       }
-//      $this->updateRevision();
 
-      $this->pushChange();
+      if ($this->getTbr()) {
+        $this->uberCreateTask($this->getRevision());
+        $this->pushChange();
+      } else if ($this->uberShouldRunSubmitQueue($this->getRevision(), $this->submitQueueRegex)) {
+        $this->pushChangeToSubmitQueue();
+      } else {
+        $this->pushChange();
+      }
+
       if ($this->shouldShadow) {
         // do nothing
       } else {
@@ -63,7 +76,13 @@ final class UberArcanistSubmitQueueEngine
     $api->execxLocal("checkout %s --", $this->getTargetOnto());
   }
 
-  private function pushChange() {
+  private function identifyRevision() {
+    $api = $this->getRepositoryAPI();
+    $api->execxLocal('checkout %s --', $this->getSourceRef());
+    call_user_func($this->getBuildMessageCallback(), $this);
+  }
+
+  private function pushChangeToSubmitQueue() {
     $this->writeInfo(
       pht('PUSHING'),
       pht('Pushing changes to Submit Queue.'));
@@ -92,27 +111,6 @@ final class UberArcanistSubmitQueueEngine
     $this->conduit = $conduit;
   }
 
-  private function updateWorkingCopy() {
-    $api = $this->getRepositoryAPI();
-
-    $api->execxLocal('checkout %s --', $this->getSourceRef());
-
-    try {
-      // merge target against source to generate the latest patch
-      $api->execxLocal('merge --no-stat %s --', $this->getTargetFullRef());
-    } catch (Exception $ex) {
-      $api->execManualLocal('merge --abort');
-      $api->execManualLocal('reset --hard HEAD --');
-
-      throw new Exception(
-        pht(
-          '"%s" does not merge cleanly into Local "%s". Merge or rebase '.
-          'local changes so they can merge cleanly.',
-          $this->getTargetFullRef(),
-          $this->getSourceRef()));
-    }
-  }
-
   final public function getRevision() {
     return $this->revision;
   }
@@ -133,6 +131,44 @@ final class UberArcanistSubmitQueueEngine
 
   final public function setSkipUpdateWorkingCopy($skipUpdateWorkingCopy) {
     $this->skipUpdateWorkingCopy = $skipUpdateWorkingCopy;
+    return $this;
+  }
+
+  public function getConduit() {
+    return $this->conduit;
+  }
+
+  public function getUserName() {
+    return $this->userName;
+  }
+
+  public function getSubmitQueueRegex() {
+    return $this->submitQueueRegex;
+  }
+
+  public function setSubmitQueueRegex($submitQueueRegex) {
+    $this->submitQueueRegex = $submitQueueRegex;
+    return $this;
+  }
+
+  public function getTbr() {
+    if (empty($this->tbr)) {
+      return false;
+    }
+    return $this->tbr;
+  }
+
+  public function setTbr($tbr) {
+    $this->tbr = $tbr;
+    return $this;
+  }
+
+  public function getSubmitQueueTags() {
+    return $this->submitQueueTags;
+  }
+
+  public function setSubmitQueueTags($submitQueueTags) {
+    $this->submitQueueTags = $submitQueueTags;
     return $this;
   }
 
@@ -163,6 +199,73 @@ final class UberArcanistSubmitQueueEngine
     $changes = id(new ArcanistDiffParser())->parseDiff($text);
     ksort($changes);
     return ArcanistBundle::newFromChanges($changes)->toGitPatch();
+  }
+
+  private function uberShouldRunSubmitQueue($revision, $regex) {
+    if (empty($regex)) {
+      return true;
+    }
+
+    $diff = head(
+      $this->getConduit()->callMethodSynchronous(
+        'differential.querydiffs',
+        array('ids' => array(head($revision['diffs'])))));
+    $changes = array();
+    foreach ($diff['changes'] as $changedict) {
+      $changes[] = ArcanistDiffChange::newFromDictionary($changedict);
+    }
+
+    foreach ($changes as $change) {
+      if (preg_match($regex, $change->getOldPath())) {
+        return true;
+      }
+
+      if (preg_match($regex, $change->getCurrentPath())) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private function uberTbrGetExcuse($prompt, $history) {
+    $console = PhutilConsole::getConsole();
+    $history = $this->getRepositoryAPI()->getScratchFilePath($history);
+    $excuse = phutil_console_prompt($prompt, $history);
+    if ($excuse == '') {
+      throw new ArcanistUserAbortException();
+    }
+    return $excuse;
+  }
+
+  private function uberCreateTask($revision) {
+    if (empty($this->getSubmitQueueTags())) {
+      return;
+    }
+
+    $console = PhutilConsole::getConsole();
+    $excuse = $this->uberTbrGetExcuse(
+      pht('Provide explanation for skipping SubmitQueue or press Enter to abort.'),
+      'tbr-excuses');
+    $args = array(
+      pht('%s is skipping SubmitQueue', 'D' . $revision['id']),
+      '--uber-description',
+      pht("%s is skipping SubmitQueue\n Author: %s\n Excuse: %s\n",
+        'D' . $revision['id'],
+        $this->getWorkflow()->getUserName(),
+        $excuse),
+      '--browse');
+    foreach ($this->submitQueueTags as $tag) {
+      array_push($args, "--project", $tag);
+    }
+
+    $owners = $this->getWorkflow()->getConfigFromAnySource("uber.land.submitqueue.owners");
+    foreach ($owners as $owner) {
+      array_push($args, "--cc", $owner);
+    }
+
+    $todo_workflow = $this->getWorkflow()->buildChildWorkflow('todo', $args);
+    $todo_workflow->run();
   }
 
   private $submitQueueClient;

--- a/src/workflow/ArcanistSubmitWorkflow.php
+++ b/src/workflow/ArcanistSubmitWorkflow.php
@@ -27,7 +27,6 @@ final class ArcanistSubmitWorkflow extends ArcanistWorkflow {
     $engine = new UberArcanistSubmitQueueEngine(
       $this->submitQueueClient,
       $this->getConduit());
-    $engine = $engine;
 
     $engine
       ->setRevision($revision)


### PR DESCRIPTION
`Arc land ${branchname}` was broken for SubmitQueue workflows. This diff is expected to fix that.

The approach I have taken is the following:
1. While trying to land changes from another branch, the branch parameter is passed to UberArcanistSubmitQueueEngine.
2. SQEngine checks out the branch and then tries to find the revision of the branch. 
3. Once the revision is identified, it passes the parameters to SQ through a REST API call. 
4. Once the REST request is successful, the branch is deleted if it can be deleted and the onto branch to which the change is expected to pushed to is checked out. 

I have checked the following workflows as part of this change.
1. Normal SQ land for a dummy repo
2. SQ land from another branch using `arc land branchname`
3. Direct land and ticket creation using --tbr
4. SQ land for a change that's covered by a regex.
5. Normal land for a change in a SQ repo that's not covered by a regex.