### PR TITLE
Diff Staging: create branches instead of tags

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -2722,8 +2722,8 @@ EOTEXT
     $commit = $api->getHeadCommit();
     $prefix = idx($staging, 'prefix', 'phabricator');
 
-    $base_tag = "refs/tags/{$prefix}/base/{$id}";
-    $diff_tag = "refs/tags/{$prefix}/diff/{$id}";
+    $base_tag = "refs/{$prefix}/base/{$id}";
+    $diff_tag = "refs/{$prefix}/diff/{$id}";
 
     $this->writeOkay(
       pht('PUSH STAGING'),


### PR DESCRIPTION
Branches are ephemeral by nature; tags are not. Creating a tag for every
revision of every diff accumulates excessively in repositories which are
high churn. Additionally, reusing a repository as a staging repo,
instead of creating a new one, forces all of these tags to be pulled
down for all developers.

Let's use branches instead of tags, as it is trivial to remove remote,
old branches as they accumulate. Removing tags is non-trivial and likely
to result in a developer accidentally re-uploading all of the deleted
tags.

--

N.B. It's possible to use a different refspec (like `refs/reviews` or `refs/phabricator` etc.) if desired.