### PR TITLE
Fix undefined offset

### DIFF
--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -1167,7 +1167,9 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
 
       // differential.query does not guarantee order. Ensure result is in order of revision-ids found
       foreach ($revision_ids as $revision_id) {
-        $finalResults[] = $results[$revisionIdToIndex[$revision_id]];
+        if (isset($revisionIdToIndex[$revision_id])) {
+          $finalResults[] = $results[$revisionIdToIndex[$revision_id]];
+        }
       }
 
       return $finalResults;


### PR DESCRIPTION
# Overview

This mitigates an issue that is caused by commit metadata being interpreted as revision ids, and then an array is incorrectly dereferenced, causing `arc diff` to fail.

This only fixes the symptom. The root cause of invalid revision ids being gathered needs to be fixed.

# Reproduction instructions

1. Create a diff with `arc diff`.

2. Reset your local branch and `arc patch $NAME_OF_YOUR_DIFF_REVISION`.

3. Perform a change and commit it.

4. `arc diff` again. This should fail with the following error: `ERROR 8: Undefined offset: $NUMERIC_PORTION_OF_YOUR_DIFF_REVISION`

# When bug was introduced

It was introduced when support for the `arc stack` command was included: 0e5599a106997d5754c691eedcce884736c99788