### PR TITLE
Don't prompt for revert plan if one already exists

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -1625,7 +1625,8 @@ EOTEXT
         $template = $commit['message'];
       } else {
         $revert_plan_check_paths = $this->getRevertPlanCheckPaths();
-        if (!is_null($revert_plan_check_paths)
+        if (!array_key_exists('revertPlan', $fields)
+          && !is_null($revert_plan_check_paths)
           && $this->modifiesPath($revert_plan_check_paths, $changes)) {
           $fields['revertPlan'] = $this->getRevertPlan();
         }


### PR DESCRIPTION
Previously, if there was already a revert plan in the commit message of HEAD, we would still redundantly prompt the user for whether the diff is flagged, etc.