### PR TITLE
Handle 409 duplicate request

### DIFF
--- a/src/land/UberSubmitQueueFuture.php
+++ b/src/land/UberSubmitQueueFuture.php
@@ -3,7 +3,10 @@
 final class UberSubmitQueueFuture extends FutureProxy {
 	protected function didReceiveResult($result) {
 		list($status, $body, $headers) = $result;
-		if ($status->isError()) {
+    // When a merge request is sent to SQ, SQ checks if there’s an existing request for
+    // the same set of parameters, if it detects a duplicate it responds with 409 status
+    // and includes the id of the request and the SQ url in the body
+		if ($status->isError() && $status->getStatusCode() != 409) {
 			throw $status;
 		}
 


### PR DESCRIPTION
When a merge request is sent to SQ, SQ checks if there’s an existing request for the same set of parameters, if it detects a duplicate it responds with a 409. Right now arc is treating the 409 as an error but we could treat it as a normal response because it includes the same body as the "normal" response:

`
[HTTP/409]
{
  "id" : 112163,
  "url" : "https://submitqueue.uberinternal.com/#/show/112163"
}
`

More context:

Sometimes SQ takes some time to respond and arc times out and treat the merge request as failure even though SQ has successfully processed it. Since the user sees a failure, tries to land again and now sees a 409 and gets stuck in the current branch. With this simple change, the user will be able to continue with the normal workflow and switch to master on the second attempt to land in case of a timeout during the first attempt.