### PR TITLE
Include amended changes in diff when revert plan checking is enabled

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -453,15 +453,7 @@ EOTEXT
 
     $this->runDiffSetupBasics();
 
-    $revert_plan_check_paths = $this->getRevertPlanCheckPaths();
-    if (!is_null($revert_plan_check_paths)) {
-      // revert plan checking only happens for certain paths in the repository
-      // so, we need to compute the changes early in this case
-      $changes = $this->generateChanges();
-      $commit_message = $this->buildCommitMessage($changes);
-    } else {
-      $commit_message = $this->buildCommitMessage();
-    }
+    $commit_message = $this->buildCommitMessage();
 
     $this->dispatchEvent(
       ArcanistEventType::TYPE_DIFF_DIDBUILDMESSAGE,
@@ -1470,7 +1462,7 @@ EOTEXT
   /**
    * @task message
    */
-  private function buildCommitMessage($changes = NULL) {
+  private function buildCommitMessage() {
     if ($this->getArgument('preview') || $this->getArgument('only')) {
       return null;
     }
@@ -1520,7 +1512,7 @@ EOTEXT
       if ($message_file) {
         return $this->getCommitMessageFromFile($message_file);
       } else {
-        return $this->getCommitMessageFromUser($changes);
+        return $this->getCommitMessageFromUser();
       }
     } else if ($is_update) {
       $revision_id = $this->normalizeRevisionID($is_update);
@@ -1567,7 +1559,7 @@ EOTEXT
   /**
    * @task message
    */
-  private function getCommitMessageFromUser($changes = NULL) {
+  private function getCommitMessageFromUser() {
     $conduit = $this->getConduit();
 
     $template = null;
@@ -1627,7 +1619,7 @@ EOTEXT
         $revert_plan_check_paths = $this->getRevertPlanCheckPaths();
         if (!array_key_exists('revertPlan', $fields)
           && !is_null($revert_plan_check_paths)
-          && $this->modifiesPath($revert_plan_check_paths, $changes)) {
+          && $this->modifiesPath($revert_plan_check_paths)) {
           $fields['revertPlan'] = $this->getRevertPlan();
         }
         $template = $conduit->callMethodSynchronous(
@@ -1770,8 +1762,9 @@ EOTEXT
   }
 
 
-  private function modifiesPath($paths_to_check, $changes) {
-    foreach ($changes as $changed_file => $contents) {
+  private function modifiesPath($paths_to_check) {
+    $changes = $this->getRepositoryAPI()->getCommitRangeStatus();
+    foreach ($changes as $changed_file => $ignored) {
       foreach ($paths_to_check as $cur_path) {
         if (preg_match($cur_path, $changed_file)) {
           return true;

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -488,11 +488,7 @@ EOTEXT
         'unit-excuses');
     }
 
-    // $changes may have already been set if revert plan checking is enabled;
-    // don't recompute
-    if (!isset($changes)) {
-      $changes = $this->generateChanges();
-    }
+    $changes = $this->generateChanges();
     if (!$changes) {
       throw new ArcanistUsageException(
         pht('There are no changes to generate a diff from!'));


### PR DESCRIPTION
7e8a278d3395c7315f0046a03ae79074a5c8eda3 introduced a bug where if `arc lint` amended HEAD with changes, those changes were not included in the submitted diff (though they were applied locally).  This PR fixes the bug by removing code that computed changes early, and instead relying on the repository API to determine if revert plan prompting should be applied.