### PR TITLE
Fix empty call which are not compatible with older php (like 5.4)

### DIFF
--- a/src/land/UberArcanistSubmitQueueEngine.php
+++ b/src/land/UberArcanistSubmitQueueEngine.php
@@ -78,9 +78,9 @@ class UberArcanistSubmitQueueEngine
     if (empty($r)) {
       $api = $this->getRepositoryAPI();
       $api->execxLocal('checkout %s --', $this->getSourceRef());
-      $b = $this->getBuildMessageCallback();
-      if (!empty($b)) {
-        call_user_func($this->getBuildMessageCallback(), $this);
+      $c = $this->getBuildMessageCallback();
+      if (!empty($c)) {
+        call_user_func($c, $this);
       } else {
         $message = pht(
           "Revision and callback empty");

--- a/src/land/UberArcanistSubmitQueueEngine.php
+++ b/src/land/UberArcanistSubmitQueueEngine.php
@@ -74,10 +74,12 @@ class UberArcanistSubmitQueueEngine
   }
 
   private function identifyRevision() {
-    if (empty($this->getRevision())) {
+    $r = $this->getRevision();
+    if (empty($r)) {
       $api = $this->getRepositoryAPI();
       $api->execxLocal('checkout %s --', $this->getSourceRef());
-      if (!empty($this->getBuildMessageCallback())) {
+      $b = $this->getBuildMessageCallback();
+      if (!empty($b)) {
         call_user_func($this->getBuildMessageCallback(), $this);
       } else {
         $message = pht(
@@ -244,7 +246,8 @@ class UberArcanistSubmitQueueEngine
   }
 
   private function uberCreateTask($revision) {
-    if (empty($this->getSubmitQueueTags())) {
+    $t = $this->getSubmitQueueTags();
+    if (empty($t)) {
       return;
     }
 


### PR DESCRIPTION
`empty()` construct currently used in code is not compatible with 5.4 or older PHP versions, fix it to support those versions