### PR TITLE
Force failing on empty binary patch

### DIFF
--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -272,6 +272,13 @@ final class ArcanistSettings extends Phobject {
           'matches staging uri.'),
         'default' => false,
       ),
+      'uber.diff.prompt.allow-empty-binary' => array(
+        'type' => 'bool',
+        'help' => pht(
+          'If true, diff with empty binary upload will produce exceptions'.
+          'unless diff explicitly with `--skip-binaries` option'),
+          'default' => true,
+      ),
     );
   }
 

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -2684,7 +2684,11 @@ EOTEXT
 
     if ($errors) {
       $prompt = pht('Continue?');
-      $ok = phutil_console_confirm($prompt, $default_no = false);
+      $allow_prompt = $this->getConfigFromAnySource("uber.diff.prompt.allow-empty-binary");
+      $ok = false;
+      if ($allow_prompt) {
+        $ok = phutil_console_confirm($prompt, $default_no = false);
+      }
       if (!$ok) {
         throw new ArcanistUsageException(
           pht(


### PR DESCRIPTION
This option has caused us some issues on SQ when developer ignores the prompt, this way at least people won't patch empty binary accidentally