### PR TITLE
Actually execute 'go vet' in GoVetLinter

### DIFF
--- a/src/lint/linter/ArcanistGoVetLinter.php
+++ b/src/lint/linter/ArcanistGoVetLinter.php
@@ -53,7 +53,7 @@ final class ArcanistGoVetLinter extends ArcanistExternalLinter {
   }
 
   protected function getMandatoryFlags() {
-    return array('tool', 'vet');
+    return array('vet');
   }
 
   public function getVersion() {
@@ -90,5 +90,4 @@ final class ArcanistGoVetLinter extends ArcanistExternalLinter {
 
     return $messages;
   }
-
 }


### PR DESCRIPTION
Linter still executed `go tool vet` which is not supported since `go1.12`.