### PR TITLE
Fix path to 'true'

### DIFF
--- a/src/lint/linter/ArcanistNoopLinter.php
+++ b/src/lint/linter/ArcanistNoopLinter.php
@@ -22,7 +22,7 @@ abstract class ArcanistNoopLinter extends ArcanistExternalLinter {
   }
 
   public function getDefaultBinary() {
-    return '/bin/true';
+    return '/usr/bin/env true';
   }
 
   public function getInstallInstructions() {

--- a/src/lint/linter/ArcanistNoopLinter.php
+++ b/src/lint/linter/ArcanistNoopLinter.php
@@ -22,7 +22,7 @@ abstract class ArcanistNoopLinter extends ArcanistExternalLinter {
   }
 
   public function getDefaultBinary() {
-    return '/usr/bin/env true';
+    return 'true';
   }
 
   public function getInstallInstructions() {

--- a/src/lint/linter/ArcanistNoopLinter.php
+++ b/src/lint/linter/ArcanistNoopLinter.php
@@ -22,7 +22,11 @@ abstract class ArcanistNoopLinter extends ArcanistExternalLinter {
   }
 
   public function getDefaultBinary() {
-    return 'true';
+    return '/usr/bin/env';
+  }
+
+  public function getDefaultFlags() {
+    return array('true');
   }
 
   public function getInstallInstructions() {

--- a/src/lint/linter/ArcanistNoopLinter.php
+++ b/src/lint/linter/ArcanistNoopLinter.php
@@ -25,16 +25,12 @@ abstract class ArcanistNoopLinter extends ArcanistExternalLinter {
     return '/usr/bin/env';
   }
 
-  public function getDefaultFlags() {
+  protected function getMandatoryFlags() {
     return array('true');
   }
 
   public function getInstallInstructions() {
     return '';
-  }
-
-  protected function getMandatoryFlags() {
-    return array();
   }
 
   public function getVersion() {


### PR DESCRIPTION
A recent change made the GOVET linter a no-op by replacing it with a call to the true command. But the path of the command is incorrect on macos, so this change uses `/usr/bin/env` to resolve the correct path.