### PR TITLE
noop'ed govet fixes: allow old options, resolve location of `true` 

### DIFF
--- a/src/lint/linter/ArcanistGoVetLinter.php
+++ b/src/lint/linter/ArcanistGoVetLinter.php
@@ -10,4 +10,10 @@ final class ArcanistGoVetLinter extends ArcanistNoopLinter {
   public function getLinterConfigurationName() {
     return 'govet';
   }
+
+  public function getLinterConfigurationOptions() {
+    // govet used to be a linter with options. noop defaults to no options.
+    // Restore by using the external linter superclass's default.
+    return ArcanistExternalLinter::getLinterConfigurationOptions();
+  }
 }

--- a/src/lint/linter/ArcanistNoopLinter.php
+++ b/src/lint/linter/ArcanistNoopLinter.php
@@ -22,7 +22,16 @@ abstract class ArcanistNoopLinter extends ArcanistExternalLinter {
   }
 
   public function getDefaultBinary() {
-    return '/bin/true';
+    // There are many possible paths to find truth in life. BSD and Linux took
+    // different paths.
+    $truebin = Filesystem::resolveBinary('true');
+    if ($truebin) {
+      return $truebin;
+    } else {
+       throw new ArcanistMissingLinterException(
+         pht('Unable to find the "true" program on your path.')
+       );
+    }
   }
 
   public function getInstallInstructions() {


### PR DESCRIPTION
Two things happened after the previous branch landed (#125). First, `govet` took options that, while rare, did exist in the wild. Hence for it to be a true noop it must ask for the old config values and do nothing with them.

Second, `true` has different locations on different systems. Linux systems, like my laptop and our build CI, place it in `/bin/true`. OS X, and likely other BSD systems, place it at `/usr/bin/true`. The location should be resolved based on the user's path, which we can do using `Filesystem` to resolve the binary.

