### PR TITLE
linter: govet: re-expose former options

### DIFF
--- a/src/lint/linter/ArcanistGoVetLinter.php
+++ b/src/lint/linter/ArcanistGoVetLinter.php
@@ -10,4 +10,10 @@ final class ArcanistGoVetLinter extends ArcanistNoopLinter {
   public function getLinterConfigurationName() {
     return 'govet';
   }
+
+  public function getLinterConfigurationOptions() {
+    // govet used to be a linter with options. noop defaults to no options.
+    // Restore by using the external linter superclass's default.
+    return ArcanistExternalLinter::getLinterConfigurationOptions();
+  }
 }


### PR DESCRIPTION
The older govet exposed ExternalLinter's options, so we should do the
same to maintain configuration backwards compatibility.

This was originally in #127, but #126's method was preferred over using `Filesystem`. This is a rebase of #127 on top of #126.