### PR TITLE
Make CPR scripts always run relative to the repository root

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -1233,7 +1233,10 @@ EOTEXT
       $prompt = $cprDef['prompt'];
       $defaultsToYes = $cprDef['default-to'];
       $resolveScript = $cprDef['resolve-script'];
-      $err = phutil_passthru('%s', $checkScript);
+      $projectRoot = $this->getWorkingCopy()->getProjectRoot();
+      $exec = new PhutilExecPassthru('%s', $checkScript);
+      $exec->setCWD($projectRoot);
+      $err = $exec->execute();
       if ($err == 0) {
         continue; // Nothing to fix
       }
@@ -1247,7 +1250,9 @@ EOTEXT
       }
       // We run the resolution script
       // (with stdin disabled so it can't be interfered with)
-      $err = phutil_passthru('%s < /dev/null', $resolveScript);
+      $exec = new PhutilExecPassthru('%s < /dev/null', $resolveScript);
+      $exec->setCWD($projectRoot);
+      $err = $exec->execute();
       if ($err == 0) {
         echo phutil_console_format(
               "\n\n%s\n\n",


### PR DESCRIPTION
Previously, a config block like this:

```
"uber.differential.check_prompt_resolve": [
    {
      "check-script" : "./tooling/arc/check_for_issue.sh",
      "prompt" : "Fix?",
      "default-to" : true,
      "resolve-script" : "./tooling/arc/fix_script.sh"
    }
  ],
```

Would work just fine when doing `arc diff` from the root of the repository, but produce the following output when run from a subdirectory:

```
sh: ./tooling/arc/dependencies-changed/check_for_issue.sh: No such file or directory

   Fix? [Y/n]
```

And a further error if the user chose 'Y'.

This patch makes it possible to run `arc diff` with CPR scripts from anywhere within a repository.