### PR TITLE
allow linter to specify chunk size on linting large diffs

### DIFF
--- a/src/lint/engine/ArcanistLintEngine.php
+++ b/src/lint/engine/ArcanistLintEngine.php
@@ -473,6 +473,7 @@ abstract class ArcanistLintEngine extends Phobject {
     return $runnable;
   }
 
+  // UBER CODE
   private function executeLinters(array $runnable) {
     assert_instances_of($runnable, 'ArcanistLinter');
 
@@ -495,7 +496,6 @@ abstract class ArcanistLintEngine extends Phobject {
     $path_map = array_fuse($path_list);
 
     $exceptions = array();
-    $did_lint = array();
 
     $linter_id = $linter->getLinterID();
     $paths = $linter->getPaths();
@@ -557,6 +557,7 @@ abstract class ArcanistLintEngine extends Phobject {
 
     return $exceptions;
   }
+  // UBER CODE END
 
   private function beginLintServiceCall(ArcanistLinter $linter, array $paths) {
     $profiler = PhutilServiceProfiler::getInstance();

--- a/src/lint/engine/ArcanistLintEngine.php
+++ b/src/lint/engine/ArcanistLintEngine.php
@@ -477,86 +477,82 @@ abstract class ArcanistLintEngine extends Phobject {
     assert_instances_of($runnable, 'ArcanistLinter');
 
     $all_paths = $this->getPaths();
-    $path_chunks = array_chunk($all_paths, 32, $preserve_keys = true);
 
     $exception_lists = array();
-    foreach ($path_chunks as $chunk) {
-      $exception_lists[] = $this->executeLintersOnChunk($runnable, $chunk);
+    foreach ($runnable as $linter) {
+      $chunk_size = $linter->getChunkSizeLimit() ? $linter->getChunkSizeLimit() : count($all_paths);
+      $path_chunks = array_chunk($all_paths, $chunk_size, $preserve_keys = true);
+      foreach ($path_chunks as $chunk) {
+        $exception_lists[] = $this->executeLinterOnChunk($linter, $chunk);
+      }
     }
 
     return array_mergev($exception_lists);
   }
 
 
-  private function executeLintersOnChunk(array $runnable, array $path_list) {
-    assert_instances_of($runnable, 'ArcanistLinter');
-
+  private function executeLinterOnChunk(ArcanistLinter $linter, array $path_list) {
     $path_map = array_fuse($path_list);
 
     $exceptions = array();
     $did_lint = array();
-    foreach ($runnable as $linter) {
-      $linter_id = $linter->getLinterID();
-      $paths = $linter->getPaths();
 
-      foreach ($paths as $key => $path) {
-        // If we aren't running this path in the current chunk of paths,
-        // skip it completely.
-        if (empty($path_map[$path])) {
-          unset($paths[$key]);
-          continue;
-        }
+    $linter_id = $linter->getLinterID();
+    $paths = $linter->getPaths();
 
-        // Make sure each path has a result generated, even if it is empty
-        // (i.e., the file has no lint messages).
-        $result = $this->getResultForPath($path);
-
-        // If a linter has stopped all other linters for this path, don't
-        // actually run the linter.
-        if (isset($this->stopped[$path])) {
-          unset($paths[$key]);
-          continue;
-        }
-
-        // If we have a cached result for this path, don't actually run the
-        // linter.
-        if (isset($this->cachedResults[$path][$this->cacheVersion])) {
-          $cached_result = $this->cachedResults[$path][$this->cacheVersion];
-
-          $use_cache = $this->shouldUseCache(
-            $linter->getCacheGranularity(),
-            idx($cached_result, 'repository_version'));
-
-          if ($use_cache) {
-            unset($paths[$key]);
-            if (idx($cached_result, 'stopped') == $linter_id) {
-              $this->stopped[$path] = $linter_id;
-            }
-          }
-        }
-      }
-
-      $paths = array_values($paths);
-
-      if (!$paths) {
+    foreach ($paths as $key => $path) {
+      // If we aren't running this path in the current chunk of paths,
+      // skip it completely.
+      if (empty($path_map[$path])) {
+        unset($paths[$key]);
         continue;
       }
 
-      try {
-        $this->executeLinterOnPaths($linter, $paths);
-        $did_lint[] = array($linter, $paths);
-      } catch (Exception $ex) {
-        $exceptions[] = $ex;
+      // Make sure each path has a result generated, even if it is empty
+      // (i.e., the file has no lint messages).
+      $result = $this->getResultForPath($path);
+
+      // If a linter has stopped all other linters for this path, don't
+      // actually run the linter.
+      if (isset($this->stopped[$path])) {
+        unset($paths[$key]);
+        continue;
+      }
+
+      // If we have a cached result for this path, don't actually run the
+      // linter.
+      if (isset($this->cachedResults[$path][$this->cacheVersion])) {
+        $cached_result = $this->cachedResults[$path][$this->cacheVersion];
+
+        $use_cache = $this->shouldUseCache(
+          $linter->getCacheGranularity(),
+          idx($cached_result, 'repository_version'));
+
+        if ($use_cache) {
+          unset($paths[$key]);
+          if (idx($cached_result, 'stopped') == $linter_id) {
+            $this->stopped[$path] = $linter_id;
+          }
+        }
       }
     }
 
-    foreach ($did_lint as $info) {
-      list($linter, $paths) = $info;
-      try {
-        $this->executeDidLintOnPaths($linter, $paths);
-      } catch (Exception $ex) {
-        $exceptions[] = $ex;
-      }
+    $paths = array_values($paths);
+
+    if (!$paths) {
+      return $exceptions;
+    }
+
+    try {
+      $this->executeLinterOnPaths($linter, $paths);
+    } catch (Exception $ex) {
+      $exceptions[] = $ex;
+    }
+
+    try {
+      $this->executeDidLintOnPaths($linter, $paths);
+    } catch (Exception $ex) {
+      $exceptions[] = $ex;
     }
 
     return $exceptions;

--- a/src/lint/linter/ArcanistLinter.php
+++ b/src/lint/linter/ArcanistLinter.php
@@ -210,6 +210,20 @@ abstract class ArcanistLinter extends Phobject {
     return;
   }
 
+  /**
+   * Get chunk size for the linter.
+   *
+   * @{class:ArcanistLintEngine} will split large path list into chunks
+   * when linting in order to have bounded memory usage.
+   * This limit controls the chunk size.
+   * When this is explicitly set to null, size will be unbounded.
+   *
+   * @return int Linting paths chunk size.
+   */
+  public function getChunkSizeLimit() {
+    return 32;
+  }
+
   public function getLinterPriority() {
     return 1.0;
   }


### PR DESCRIPTION
The chunk size affects iOS repo arc performance heavily since we do some buck pre-loading in `WillLintPaths`. 
Anding an option to specify this in linter level would help ease the issue.
This option also comes up in the discussion in https://secure.phabricator.com/D12501, but never implemented since.

Local metrics with local iOS repo with:
```
git reset HEAD~10
arc lint
```

with chunk size of 32: 1m18.846s
with unbounded chunk size: 42s
a 46% drop down