### PR TITLE
Only update submodules when we have submodules

### DIFF
--- a/src/land/ArcanistGitLandEngine.php
+++ b/src/land/ArcanistGitLandEngine.php
@@ -35,12 +35,7 @@ class ArcanistGitLandEngine
         $this->reconcileLocalState();
 
         $api = $this->getRepositoryAPI();
-        list($out) = $api->execxLocal(
-            'config --file .gitmodules --name-only --get-regexp path');
-        $haveSubmodules = strlen(trim($out));
-        if ($haveSubmodules) {
-            $api->execxLocal('submodule update --init --recursive');
-        }
+        $api->uberUpdateGitSubmodules();
 
         if ($this->getShouldKeep()) {
           echo tsprintf(
@@ -531,13 +526,7 @@ class ArcanistGitLandEngine
 
     $api->execxLocal('checkout %s --', $this->localRef);
     $api->execxLocal('reset --hard %s --', $this->localCommit);
-
-    list($out) = $api->execxLocal(
-        'config --file .gitmodules --name-only --get-regexp path');
-    $haveSubmodules = strlen(trim($out));
-    if ($haveSubmodules) {
-        $api->execxLocal('submodule update --init --recursive');
-    }
+    $api->uberUpdateGitSubmodules();
 
     $this->restoreWhenDestroyed = false;
   }

--- a/src/land/ArcanistGitLandEngine.php
+++ b/src/land/ArcanistGitLandEngine.php
@@ -35,7 +35,12 @@ class ArcanistGitLandEngine
         $this->reconcileLocalState();
 
         $api = $this->getRepositoryAPI();
-        $api->execxLocal('submodule update --init --recursive');
+        list($out) = $api->execxLocal(
+            'config --file .gitmodules --name-only --get-regexp path');
+        $haveSubmodules = strlen(trim($out));
+        if ($haveSubmodules) {
+            $api->execxLocal('submodule update --init --recursive');
+        }
 
         if ($this->getShouldKeep()) {
           echo tsprintf(
@@ -526,7 +531,13 @@ class ArcanistGitLandEngine
 
     $api->execxLocal('checkout %s --', $this->localRef);
     $api->execxLocal('reset --hard %s --', $this->localCommit);
-    $api->execxLocal('submodule update --init --recursive');
+
+    list($out) = $api->execxLocal(
+        'config --file .gitmodules --name-only --get-regexp path');
+    $haveSubmodules = strlen(trim($out));
+    if ($haveSubmodules) {
+        $api->execxLocal('submodule update --init --recursive');
+    }
 
     $this->restoreWhenDestroyed = false;
   }

--- a/src/land/ArcanistGitLandEngine.php
+++ b/src/land/ArcanistGitLandEngine.php
@@ -35,7 +35,9 @@ class ArcanistGitLandEngine
         $this->reconcileLocalState();
 
         $api = $this->getRepositoryAPI();
-        $api->uberUpdateGitSubmodules();
+        if ($api->uberHasGitSubmodules()) {
+            $api->execxLocal('submodule update --init --recursive');
+        }
 
         if ($this->getShouldKeep()) {
           echo tsprintf(
@@ -526,7 +528,9 @@ class ArcanistGitLandEngine
 
     $api->execxLocal('checkout %s --', $this->localRef);
     $api->execxLocal('reset --hard %s --', $this->localCommit);
-    $api->uberUpdateGitSubmodules();
+    if ($api->uberHasGitSubmodules()) {
+        $api->execxLocal('submodule update --init --recursive');
+    }
 
     $this->restoreWhenDestroyed = false;
   }

--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -1594,4 +1594,15 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
     return $path;
   }
 
+  /**
+   * Recursively udpate submodules if we have any.
+   */
+  public function uberUpdateGitSubmodules() {
+        list($out) = $this->execxLocal(
+            'config --file .gitmodules --name-only --get-regexp path');
+        $haveSubmodules = strlen(trim($out));
+        if ($haveSubmodules) {
+            $this->execxLocal('submodule update --init --recursive');
+        }
+  }
 }

--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -1595,14 +1595,11 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
   }
 
   /**
-   * Recursively udpate submodules if we have any.
+   * Check whether repository has submodules that need updating
    */
-  public function uberUpdateGitSubmodules() {
+  public function uberHasGitSubmodules() {
         list($out) = $this->execxLocal(
             'config --file .gitmodules --name-only --get-regexp path');
-        $haveSubmodules = strlen(trim($out));
-        if ($haveSubmodules) {
-            $this->execxLocal('submodule update --init --recursive');
-        }
+        return strlen(trim($out));
   }
 }

--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -1598,8 +1598,12 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
    * Check whether repository has submodules that need updating
    */
   public function uberHasGitSubmodules() {
+      try {
         list($out) = $this->execxLocal(
             'config --file .gitmodules --name-only --get-regexp path');
-        return strlen(trim($out));
+      } catch (CommandException $ex) {
+        return false;
+      }
+      return strlen(trim($out));
   }
 }

--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -1604,6 +1604,6 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
       } catch (CommandException $ex) {
         return false;
       }
-      return strlen(trim($out));
+      return (bool)strlen(trim($out));
   }
 }

--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -1587,12 +1587,7 @@ EOTEXT
     $repository_api = $this->getRepositoryAPI();
     $repository_api->execxLocal('checkout %s', $this->oldBranch);
     if ($this->isGit) {
-      list($out) = $repository_api->execxLocal(
-          'config --file .gitmodules --name-only --get-regexp path');
-      $haveSubmodules = strlen(trim($out));
-      if ($haveSubmodules) {
-          $repository_api->execxLocal('submodule update --init --recursive');
-      }
+      $repository_api->uberUpdateGitSubmodules();
     }
     echo pht(
       "Switched back to %s %s.\n",

--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -1587,7 +1587,9 @@ EOTEXT
     $repository_api = $this->getRepositoryAPI();
     $repository_api->execxLocal('checkout %s', $this->oldBranch);
     if ($this->isGit) {
-      $repository_api->uberUpdateGitSubmodules();
+        if ($repository_api->uberHasGitSubmodules()) {
+            $repository_api->execxLocal('submodule update --init --recursive');
+        }
     }
     echo pht(
       "Switched back to %s %s.\n",

--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -1587,7 +1587,12 @@ EOTEXT
     $repository_api = $this->getRepositoryAPI();
     $repository_api->execxLocal('checkout %s', $this->oldBranch);
     if ($this->isGit) {
-      $repository_api->execxLocal('submodule update --init --recursive');
+      list($out) = $repository_api->execxLocal(
+          'config --file .gitmodules --name-only --get-regexp path');
+      $haveSubmodules = strlen(trim($out));
+      if ($haveSubmodules) {
+          $repository_api->execxLocal('submodule update --init --recursive');
+      }
     }
     echo pht(
       "Switched back to %s %s.\n",


### PR DESCRIPTION
VFS for git can't work with submodules, so we check if we have submodules before trying. This way we avoid errors while at the same time not affecting repositories that actually have submodules.