### PR TITLE
Fix #141: Handle push to submitqueue gracefully when pushurl is absent

### DIFF
--- a/src/land/UberArcanistSubmitQueueEngine.php
+++ b/src/land/UberArcanistSubmitQueueEngine.php
@@ -99,7 +99,7 @@ class UberArcanistSubmitQueueEngine
       $this->getTargetRemote());
     $remoteUrl = trim($out);
 
-    list($out) = $api->execxLocal(
+    list(, $out) = $api->execManualLocal(
       'config --get remote.%s.pushurl',
       $this->getTargetRemote());
     $remotePushUrl = trim($out);


### PR DESCRIPTION
`execLocal` throws exception when underlying command returns non-zero exit code.
`execManualLocal` calls `resolve` which returns error which can be handled gracefully. 