### PR TITLE
--skip-set-dependency and --skip-decompose is not needed

### DIFF
--- a/src/flow/workflow/ICSyncWorkflow.php
+++ b/src/flow/workflow/ICSyncWorkflow.php
@@ -215,8 +215,6 @@ EOTEXT
             'D'.$revision_id,
             '--message',
             $message,
-            '--skip-set-dependency',
-            '--skip-decompose',
           );
           if ($branch_status[$branch_name] == $changes_planned) {
             array_push($diff_args, '--plan-changes');


### PR DESCRIPTION
Uber (semi upstream) arcanist doesn't have `--skip-set-dependency` nor `--skip-decompose` options, it is default behavior actually. This unbreak `arc sync --revisions` functionality.