### PR TITLE
arc flow depends on upstream branch setup but git.default-relative-commit in  is overriding everything, let's add workaround for it

### DIFF
--- a/src/flow/workflow/ICFlowWorkflow.php
+++ b/src/flow/workflow/ICFlowWorkflow.php
@@ -74,6 +74,7 @@ EOTEXT
           " - **Two branches** to declare what branch the new branch will ".
           "track from, and checkout that new branch.\n")));
       }
+      $this->markFlowUsage();
       return 0;
     }
 
@@ -96,4 +97,8 @@ EOTEXT
     return 0;
   }
 
+  private function markFlowUsage() {
+    $git = $this->getRepositoryAPI();
+    $git->writeScratchFile('uses-arc-flow', 'true');
+  }
 }

--- a/src/repository/api/ArcanistGitAPI.php
+++ b/src/repository/api/ArcanistGitAPI.php
@@ -279,6 +279,7 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
     $do_write = false;
     $default_relative = null;
     $working_copy = $this->getWorkingCopyIdentity();
+
     if ($working_copy) {
       $default_relative = $working_copy->getProjectConfig(
         'git.default-relative-commit');
@@ -290,6 +291,12 @@ final class ArcanistGitAPI extends ArcanistRepositoryAPI {
           'git.default-relative-commit',
           '.arcconfig'));
     }
+
+    // UBER CODE
+    if ($this->readScratchFile('uses-arc-flow') === 'true') {
+      $default_relative = null;
+    }
+    // UBER CODE END
 
     if (!$default_relative) {
       list($err, $upstream) = $this->execManualLocal(


### PR DESCRIPTION
`arc flow` will mark "itself" whenever it is used and this way we will know that we should skip git.default-relative-commit setting set in `.arcconfig` this will make all repositories with that semi-redundant option compatible with `arc flow` workflow