### PR TITLE
One more place in arc graft functionality where we need to query activeDiff

### DIFF
--- a/src/flow/workflow/ICGraftWorkflow.php
+++ b/src/flow/workflow/ICGraftWorkflow.php
@@ -51,7 +51,9 @@ EOTEXT
       throw new ArcanistUsageException(
         'You must provide a revision (eg D123) as an argument.');
     }
-    $revision = $this->integratorFlowEmulator(array($revision_id));
+    $revision = $this->integratorFlowEmulator(array($revision_id),
+                                              array(),
+                                              array(), true);
     $revision = head($revision);
     if (!$revision) {
       throw new ArcanistUsageException(pht('No revision "%s" found.',


### PR DESCRIPTION
I only fixed one place in `graft` functionality which needed `activeDiff`, during testing another one was found