### PR TITLE
Do not try to tidy branches which are behind upstream

### DIFF
--- a/src/flow/workflow/ICTidyWorkflow.php
+++ b/src/flow/workflow/ICTidyWorkflow.php
@@ -90,6 +90,11 @@ EOTEXT
     $abandoned = array();
     $orphaned = $this->loadBrokenBranches();
     foreach ($graph->getNodesInTopologicalOrder() as $branch_name) {
+      if ($printed_branches[$branch_name]['behind']) {
+        $this->writeWarn('WARNING',
+          phutil_console_format("Branch %s is behind it's upstream skipping ".
+                                "tiding, run `arc cascade`", $branch_name));
+      }
       if ($printed_branches[$branch_name]['status'] == 'Deleted') {
         $deleted[] = $branch_name;
       }


### PR DESCRIPTION
Branches which are behind upstream might be accidentally deleted if differential revision they were based of are closed then branch can be treated as one associated with that Differential Revision and can be wiped because Revision is closed