### PR TITLE
Improve error to stop confusing engineers how to use `arc flow`

### DIFF
--- a/src/flow/ICFlowSummary.php
+++ b/src/flow/ICFlowSummary.php
@@ -84,7 +84,7 @@ final class ICFlowSummary extends PhutilConsoleView {
           pht(
             'Issue `%s` in order to create a new local tracking branch '.
             'starting from your current branch (%s).',
-            'flow branch branchname',
+            'arc flow [branchname] [upstream_branch]',
             $current_feature->getName())
         :
           '';


### PR DESCRIPTION
When there are no branches for `arc flow` to display it will return suggestion which is a bit misleading.