### PR TITLE
Let `arc cascade` rebase differently if it knows to which differential revision branch belongs too

### DIFF
--- a/src/flow/model/ICFlowFeature.php
+++ b/src/flow/model/ICFlowFeature.php
@@ -4,6 +4,9 @@ final class ICFlowFeature extends Phobject {
 
   private $head;
   private $differentialCommitMessage = null;
+  // commit sha which has differential commit message, essentially where
+  // differential revision starts
+  private $revisionBaseCommit = null;
   private $revision;
   private $search;
   private $activeDiff;
@@ -45,6 +48,7 @@ final class ICFlowFeature extends Phobject {
         $log->getMetadata('message'));
       if ($message->getRevisionID() != null) {
         $feature->differentialCommitMessage = $message;
+        $feature->revisionBaseCommit = $log->getCommitHash();
         break;
       }
     }
@@ -89,6 +93,10 @@ final class ICFlowFeature extends Phobject {
       return null;
     }
     return $this->differentialCommitMessage->getRevisionID();
+  }
+
+  public function getRevisionBaseCommit() {
+    return $this->revisionBaseCommit;
   }
 
   public function getSearchField($index, $default = null) {


### PR DESCRIPTION
`arc cascade` tries alternative technique if usual `git rebase` fails, it uses `git rebase --onto` which is essentially cherry picks commits which were done in revision