### PR TITLE
Store rebaseOnto exit code,

### DIFF
--- a/src/flow/workflow/ICCascadeWorkflow.php
+++ b/src/flow/workflow/ICCascadeWorkflow.php
@@ -110,7 +110,7 @@ EOTEXT
           echo ' usual `git rebase` flow failed, trying different '.
                "technique (rebase --onto)";
           $api->execxLocal('rebase --abort');
-          $this->rebaseOnto($branch_name,
+          list($err, $stdout, $stderr) = $this->rebaseOnto($branch_name,
                             $feature->getRevisionBaseCommit().'^',
                             $child_branch);
         }


### PR DESCRIPTION
We need to store exit code of rebaseOnto - otherwise if this strategy is successful - we still fail