### PR TITLE
Implement cherry-pick technique during `arc stack` lands

### DIFF
--- a/src/land/UberArcanistStackSubmitQueueEngine.php
+++ b/src/land/UberArcanistStackSubmitQueueEngine.php
@@ -182,7 +182,6 @@ final class UberArcanistStackSubmitQueueEngine
       } else {
         $err = phutil_passthru('git rebase %s', $ontoBranch);
         if ($err) {
-
           throw new ArcanistUsageException(pht(
             "'%s' failed. You can abort with '%s', or resolve conflicts " .
             "and use '%s' to continue forward. After resolving the rebase, " .

--- a/src/land/UberArcanistStackSubmitQueueEngine.php
+++ b/src/land/UberArcanistStackSubmitQueueEngine.php
@@ -182,6 +182,7 @@ final class UberArcanistStackSubmitQueueEngine
       } else {
         $err = phutil_passthru('git rebase %s', $ontoBranch);
         if ($err) {
+
           throw new ArcanistUsageException(pht(
             "'%s' failed. You can abort with '%s', or resolve conflicts " .
             "and use '%s' to continue forward. After resolving the rebase, " .

--- a/src/land/UberArcanistSubmitQueueEngine.php
+++ b/src/land/UberArcanistSubmitQueueEngine.php
@@ -11,6 +11,7 @@ class UberArcanistSubmitQueueEngine
   private $submitQueueRegex;
   private $tbr;
   private $submitQueueTags;
+  private $usesArcFlow;
 
   public function execute() {
     $this->verifySourceAndTargetExist();
@@ -112,9 +113,10 @@ class UberArcanistSubmitQueueEngine
       pht('Please use "%s" to track your changes', $statusUrl));
   }
 
-  public function __construct($submitQueueClient, $conduit) {
+  public function __construct($submitQueueClient, $conduit, $usesArcFlow = false) {
     $this->submitQueueClient = $submitQueueClient;
     $this->conduit = $conduit;
+    $this->usesArcFlow = $usesArcFlow;
   }
 
   final public function getRevision() {
@@ -295,5 +297,9 @@ class UberArcanistSubmitQueueEngine
 
   protected function validate() {
     assert(!empty($this->revision));
+  }
+
+  public function getUsesArcFlow() {
+    return $this->usesArcFlow;
   }
 }

--- a/src/workflow/ArcanistStackWorkflow.php
+++ b/src/workflow/ArcanistStackWorkflow.php
@@ -28,6 +28,7 @@ final class ArcanistStackWorkflow extends ArcanistWorkflow {
   private $revision_ids; // Stack of revision-ids
   private $messageFile;
   private $traceModeEnabled;
+  private $usesArcFlow;
 
   const REFTYPE_BRANCH = 'branch';
   const REFTYPE_BOOKMARK = 'bookmark';
@@ -343,7 +344,9 @@ EOTEXT
       $this->uberRunUnit();
     }
 
-    $engine = new UberArcanistStackSubmitQueueEngine($this->submitQueueClient, $this->getConduit());
+    $engine = new UberArcanistStackSubmitQueueEngine($this->submitQueueClient,
+                                                     $this->getConduit(),
+                                                     $this->getUsesArcFlow());
     $this->readEngineArguments();
     $this->requireCleanWorkingCopy();
     $should_hold = $this->getArgument('hold');
@@ -593,6 +596,7 @@ EOTEXT
           $this->getConduit()->getConduitToken());
       $this->submitQueueTags = $this->getConfigFromAnySource('uber.land.submitqueue.tags');
     }
+    $this->usesArcFlow = $this->readScratchFile('uses-arc-flow') == 'true';
   }
 
   private function findRevisions() {
@@ -863,5 +867,9 @@ EOTEXT
     if ( $this->traceModeEnabled) {
       echo phutil_console_format(call_user_func_array('pht', $message));
     }
+  }
+
+  public function getUsesArcFlow() {
+    return $this->usesArcFlow;
   }
 }


### PR DESCRIPTION
`arc stack` relies that stacked branches do not have more than 1 commit or those commits do not touch same files as stacked above change