### PR TITLE
Remove unnecessary 'binary' option; change install instructions

### DIFF
--- a/src/lint/linter/UberGitSecretsLinter.php
+++ b/src/lint/linter/UberGitSecretsLinter.php
@@ -22,36 +22,14 @@ final class UberGitSecretsLinter extends ArcanistExternalLinter {
     return 'git-secrets';
   }
 
-  public function getLinterConfigurationOptions() {
-    $options = array(
-      'binary' => array(
-        'type' => 'optional string',
-        'help' => 'git-secrets binary to execute',
-      ),
-    );
-
-    return $options + parent::getLinterConfigurationOptions();
-  }
-
-  public function setLinterConfigurationValue($key, $value) {
-    switch ($key) {
-      case 'binary':
-        $this->setBinary($value);
-        return;
-
-      default:
-        return parent::setLinterConfigurationValue($key, $value);
-    }
-  }
-
   public function getDefaultBinary() {
     return '/usr/local/etc/git-secrets/git-secrets';
   }
 
   public function getInstallInstructions() {
     return pht(
-      'Install git-secrets with `%s`.',
-      'sudo chef-client');
+      'In a monorepo, git-secrets should already be present alongside other'.
+      'tooling. To install for use in another repo, use `sudo chef-client`.');
   }
 
   protected function getMandatoryFlags() {


### PR DESCRIPTION
This removes the `binary` option, which is (1) unnecessary because `ArcanistExternalLinter` already includes a `bin` option, and (2) problematic because it does not correctly resolve binaries in paths relative to the root of the repository, unlike the existing `bin` option.

It also changes the "install instructions" to be more helpful and accurate.