### PR TITLE
When `wip` keyword is detected in differential revision title - offer to use Changes planned option which will silently create Diff

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -574,8 +574,27 @@ EOTEXT
       if ($this->getArgument('plan-changes')) {
           $revision['fields']['plan-changes'] = true;
       }
+      $wip = (bool)preg_match('/\bwip\b/i', $revision['fields']['title']);
       // UBER CODE END
       if ($commit_message->getRevisionID()) {
+        // UBER CODE
+        if ($wip && !idx($revision['fields'], 'plan-changes', false)) {
+          // fetch revision status
+          $rev = $this->getConduit()->callMethodSynchronous(
+          'differential.query',
+          array(
+            'ids' => array($commit_message->getRevisionID()),
+          ));
+          $rev = head($rev);
+          if (idx($rev, 'statusName', false) == 'Changes Planned') {
+            $this->writeInfo("Changes Planned", phutil_console_format(
+              pht('Keyword "wip" detected and Differential Revision D%s is in '.
+                  '<fg:green>Changes Planned<fg> status, keeping same status',
+              $commit_message->getRevisionID())));
+            $revision['fields']['plan-changes'] = true;
+          }
+        }
+        // UBER CODE END
         $result = $conduit->callMethodSynchronous(
           'differential.updaterevision',
           $revision);
@@ -588,6 +607,18 @@ EOTEXT
 
         echo pht('Updated an existing Differential revision:')."\n";
       } else {
+        // UBER CODE
+        if ($wip && !idx($revision['fields'], 'plan-changes', false)) {
+          $prompt = 'Keyword "wip" was detected, do you want to set '.
+            'differential to <fg:green>Changes planned</fg> status which will '.
+            ' not send notifications to subscribers and reviewers of this '.
+            'change? You can later change state via Web UI or by changing '.
+            'change title during next revision';
+          if (phutil_console_confirm(phutil_console_format($prompt), false)) {
+            $revision['fields']['plan-changes'] = true;
+          }
+        }
+        // UBER CODE END
         $revision = $this->dispatchWillCreateRevisionEvent($revision);
 
         $result = $conduit->callMethodSynchronous(

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -587,9 +587,9 @@ EOTEXT
           ));
           $rev = head($rev);
           if (idx($rev, 'statusName', false) == 'Changes Planned') {
-            $this->writeInfo("Changes Planned", phutil_console_format(
+            $this->writeInfo('Changes Planned', phutil_console_format(
               pht('Keyword "wip" detected and Differential Revision D%s is in '.
-                  '<fg:green>Changes Planned<fg> status, keeping same status',
+                  '<fg:green>Changes Planned</fg> status, keeping same status',
               $commit_message->getRevisionID())));
             $revision['fields']['plan-changes'] = true;
           }

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -588,9 +588,9 @@ EOTEXT
           $rev = head($rev);
           if (idx($rev, 'statusName', false) == 'Changes Planned') {
             $this->writeInfo('Changes Planned', phutil_console_format(
-              pht('Keyword "wip" detected and Differential Revision D%s is in '.
-                  '<fg:green>Changes Planned</fg> status, keeping same status',
-              $commit_message->getRevisionID())));
+              pht('Keyword "wip" found in title and Differential Revision D%s '.
+                  'is in <fg:green>Changes Planned</fg> status, keeping same '.
+                  'status', $commit_message->getRevisionID())));
             $revision['fields']['plan-changes'] = true;
           }
         }
@@ -609,9 +609,9 @@ EOTEXT
       } else {
         // UBER CODE
         if ($wip && !idx($revision['fields'], 'plan-changes', false)) {
-          $prompt = 'Keyword "wip" was detected, do you want to set '.
-            'differential to <fg:green>Changes planned</fg> status which will '.
-            ' not send notifications to subscribers and reviewers of this '.
+          $prompt = 'Keyword "wip" found in revision title, do you want to '.
+            'set differential to <fg:green>Changes planned</fg> status which '.
+            'will not send notifications to subscribers and reviewers of this '.
             'change? You can later change status via Web UI or by changing '.
             'change title during next revision';
           if (phutil_console_confirm(phutil_console_format($prompt), false)) {

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -612,7 +612,7 @@ EOTEXT
           $prompt = 'Keyword "wip" was detected, do you want to set '.
             'differential to <fg:green>Changes planned</fg> status which will '.
             ' not send notifications to subscribers and reviewers of this '.
-            'change? You can later change state via Web UI or by changing '.
+            'change? You can later change status via Web UI or by changing '.
             'change title during next revision';
           if (phutil_console_confirm(phutil_console_format($prompt), false)) {
             $revision['fields']['plan-changes'] = true;


### PR DESCRIPTION
When new diff is created:
![image](https://user-images.githubusercontent.com/1893606/71361274-2c343900-259b-11ea-876c-51ab413ea583.png)
When diff is updated but title is still WIP:
![image](https://user-images.githubusercontent.com/1893606/71361407-91882a00-259b-11ea-9fd2-fe5b3d764610.png)
