### PR TITLE
[arc patch] Fetch refs from repository if it is needed to patch changes

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -500,7 +500,9 @@ EOTEXT
           $bundle->getBaseRevision());
         // UBER CODE
         if (!$has_base_revision) {
-          $this->pullHashFromAllRemotes($bundle->getBaseRevision());
+          $this->pullFromAllRemotesUntilFound($bundle->getBaseRevision());
+          $has_base_revision = $repository_api->hasLocalCommit(
+            $bundle->getBaseRevision());
         }
         // UBER CODE
       }
@@ -1252,9 +1254,9 @@ EOTEXT
     return self::SUCCESS;
   }
 
-  // fetches hash from any remote repository has configured and also from
-  // staging if repo has one
-  private function pullHashFromAllRemotes($hash) {
+  // fetches hash from any remote repository configured and also from
+  // staging if repository has one
+  private function pullFromAllRemotesUntilFound($hash) {
     if (!$hash) {
       return;
     }
@@ -1271,6 +1273,9 @@ EOTEXT
     }
     foreach ($remotes as $remote) {
       $repository_api->execManualLocal('fetch %s %s', $remote, $hash);
+      if ($repository_api->hasLocalCommit($hash)) {
+        break;
+      }
     }
   }
 

--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -498,6 +498,11 @@ EOTEXT
         $repository_api->execManualLocal('fetch --quiet --all');
         $has_base_revision = $repository_api->hasLocalCommit(
           $bundle->getBaseRevision());
+        // UBER CODE
+        if (!$has_base_revision) {
+          $this->pullHashFromAllRemotes($bundle->getBaseRevision());
+        }
+        // UBER CODE
       }
     }
 
@@ -1247,11 +1252,33 @@ EOTEXT
     return self::SUCCESS;
   }
 
+  // fetches hash from any remote repository has configured and also from
+  // staging if repo has one
+  private function pullHashFromAllRemotes($hash) {
+    if (!$hash) {
+      return;
+    }
+    $remotes = array();
+    list($success, $message, $staging, $staging_uri) =
+      $this->validateStagingSetup();
+    if ($success) {
+      $remotes[] = $staging_uri;
+    }
+    $repository_api = $this->getRepositoryAPI();
+    list($err, $stdin, $stderr) = $repository_api->execManualLocal('remote');
+    if (!$err) {
+      $remotes = array_merge($remotes, array_filter(explode(PHP_EOL, $stdin)));
+    }
+    foreach ($remotes as $remote) {
+      $repository_api->execManualLocal('fetch %s %s', $remote, $hash);
+    }
+  }
+
   private function mergeBranchFromStagingArea($id, $bundle) {
     list($success,
       $message, $staging, $staging_uri) = $this->validateStagingSetup();
     if (!$success) {
-      throw new ArcanistUsageException(pht($message));
+      throw new ArcanistUsageException($message);
     }
     $prefix = idx($staging, 'prefix', 'phabricator');
     $diff_tag = $this->uberRefProvider->getDiffRefName($prefix, $id);
@@ -1269,7 +1296,7 @@ EOTEXT
     if ($err) {
       $this->writeWarn(pht('MERGE TAG FAILED'),
         pht('Unable to merge tag'));
-      throw new ArcanistUsageException(pht($message));
+      throw new ArcanistUsageException($message);
     }
 
     if ($this->shouldCommit()) {


### PR DESCRIPTION
`arc patch` was not pulling uber specific refs when simple `arc patch DXXXX` was executed, it was only pulling when specific diff was patched, make it work in all cases.

This will also improve staging support in jenkins as we will no longer need to actually setup staging and pull refs.