### PR TITLE
Publish imp check for everyone (Removed ARC_BETA env check)

### DIFF
--- a/src/workflow/ArcanistLandWorkflow.php
+++ b/src/workflow/ArcanistLandWorkflow.php
@@ -947,9 +947,7 @@ EOTEXT
     // UBER CODE
     // Check if all paths were reviewed by reviewers listed on METADATA files.
     // If this check throws an exception - silently pass.
-    if (getenv("ARC_BETA") == "1") {
-      $this->uberMetadataReviewersCheck($rev_id);
-    }
+    $this->uberMetadataReviewersCheck($rev_id);
     // UBER CODE END
 
     if ($state_warning !== null) {


### PR DESCRIPTION
Imp check introduced on #171 could be enabled only if `ARC_BETA` env variable was set to 1. Remove this condition and roll out feature to all users.