### PR TITLE
[arc flow] Changed lines reporting will correctly show changes since start of revision, rename BaseCommit to FirstCommit as it is more correct name

### DIFF
--- a/src/flow/field/ICFlowChangedLinesField.php
+++ b/src/flow/field/ICFlowChangedLinesField.php
@@ -16,8 +16,12 @@ final class ICFlowChangedLinesField extends ICFlowField {
 
   protected function getFutures(ICFlowWorkspace $workspace) {
     $max_del_lines = 0;
+    $git = $workspace->getGitAPI();
     foreach ($workspace->getFeatures() as $branch => $feature) {
       $local_diff = $feature->getHead()->getHeadDiff();
+      if ($feature->getRevisionFirstCommit()) {
+         $local_diff = $git->getAPI()->getFullGitDiff($feature->getRevisionFirstCommit()."^", $feature->getHead()->getObjectName());
+      }
       if ($local_diff) {
         $md5 = md5($local_diff);
         $cache_key = "diff-{$md5}-add-del";

--- a/src/flow/model/ICFlowFeature.php
+++ b/src/flow/model/ICFlowFeature.php
@@ -6,7 +6,7 @@ final class ICFlowFeature extends Phobject {
   private $differentialCommitMessage = null;
   // commit sha which has differential commit message, essentially where
   // differential revision starts
-  private $revisionBaseCommit = null;
+  private $revisionFirstCommit = null;
   private $revision;
   private $search;
   private $activeDiff;
@@ -48,7 +48,7 @@ final class ICFlowFeature extends Phobject {
         $log->getMetadata('message'));
       if ($message->getRevisionID() != null) {
         $feature->differentialCommitMessage = $message;
-        $feature->revisionBaseCommit = $log->getCommitHash();
+        $feature->revisionFirstCommit = $log->getCommitHash();
         break;
       }
     }
@@ -95,8 +95,8 @@ final class ICFlowFeature extends Phobject {
     return $this->differentialCommitMessage->getRevisionID();
   }
 
-  public function getRevisionBaseCommit() {
-    return $this->revisionBaseCommit;
+  public function getRevisionFirstCommit() {
+    return $this->revisionFirstCommit;
   }
 
   public function getSearchField($index, $default = null) {

--- a/src/flow/workflow/ICCascadeWorkflow.php
+++ b/src/flow/workflow/ICCascadeWorkflow.php
@@ -118,7 +118,7 @@ EOTEXT
                "technique (rebase --onto)";
           $api->execxLocal('rebase --abort');
           list($err, $stdout, $stderr) = $this->rebaseOnto($branch_name,
-                            $feature->getRevisionBaseCommit().'^',
+                            $feature->getRevisionFirstCommit().'^',
                             $child_branch);
         }
       }


### PR DESCRIPTION
`arc flow` was showing changes since last commit, if amend technique was used - changed lines was correct but if commit based flow in branch - incorrect, now it tries to show from revision start.