### PR TITLE
In `arc patch --arcbundle` workflow there might be a need to actually authenticate with Phabricator

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -500,6 +500,7 @@ EOTEXT
           $bundle->getBaseRevision());
         // UBER CODE
         if (!$has_base_revision) {
+          $this->authenticateConduit();
           $this->pullFromAllRemotesUntilFound($bundle->getBaseRevision());
           $has_base_revision = $repository_api->hasLocalCommit(
             $bundle->getBaseRevision());
@@ -530,6 +531,7 @@ EOTEXT
       $new_branch = $this->createBranch($bundle, $has_base_revision);
     }
     if (!$has_base_revision && $this->shouldApplyDependencies()) {
+      $this->authenticateConduit(); // UBER CODE
       $this->applyDependencies($bundle);
     }
 


### PR DESCRIPTION
`arc patch --arcbundle` should in general be mostly local operation but there are cases when it actually needs access to phabricator.
Some more defailts: https://secure.phabricator.com/D20972

Issue is whenever - repo has no base commit - it tries to use phabricator API which has to be authenticated, by default `arc patch` is not trying to auth.