### PR TITLE
Template coverage command with cover tmp file.

### DIFF
--- a/src/unit/engine/ConfigurablePytestTestEngine.php
+++ b/src/unit/engine/ConfigurablePytestTestEngine.php
@@ -23,7 +23,7 @@ final class ConfigurablePytestTestEngine extends UberConfigurableTestEngine {
 
   public function buildTestFuture($junit_tmp, $cover_tmp) {
     $coverage_command = $this->getCoverageCommand('unit.pytest.command');
-    $cmd_line = csprintf($coverage_command, $junit_tmp);
+    $cmd_line = csprintf($coverage_command, $junit_tmp, $cover_tmp);
 
     return new ExecFuture('%C', $cmd_line);
   }


### PR DESCRIPTION
`ConfigurablePytestTestEngine` requires two "%s" placeholders (see https://github.com/uber/arcanist/blob/master/src/unit/engine/UberConfigurableTestEngine.php#L23) but does not template the test command with the coverage file path.