### PR TITLE
[arc flow] Do not process branches which are not know by arc flow

### DIFF
--- a/src/flow/workflow/ICTidyWorkflow.php
+++ b/src/flow/workflow/ICTidyWorkflow.php
@@ -90,6 +90,9 @@ EOTEXT
     $abandoned = array();
     $orphaned = $this->loadBrokenBranches();
     foreach ($graph->getNodesInTopologicalOrder() as $branch_name) {
+      if (!idx($printed_branches, $branch_name)) {
+        continue;
+      }
       if ($printed_branches[$branch_name]['status'] == 'Deleted') {
         $deleted[] = $branch_name;
       }


### PR DESCRIPTION
`arc tidy` will print warning for deep branches:
```
[2020-04-03 14:40:38] ERROR 8: Undefined index: diff10 at [/home/artms/opt/arcanist/src/flow/workflow/ICTidyWorkflow.php:102]
arcanist(head=sync_diffs, ref.master=bba51dab73ed, ref.sync_diffs=0f2fad30f4e7), phutil(head=deployment, ref.master=9a9d94dc6ea7, ref.deployment=048e10231a43)
  #0 ICTidyWorkflow::run() called at [<arcanist>/scripts/arcanist.php:394]
```
These branches are disconnected from master hence no point processing them anyway...