### PR TITLE
[arc stack] Add new state of harbormaster builds to check against during `arc stack` lands

### DIFF
--- a/src/workflow/ArcanistStackWorkflow.php
+++ b/src/workflow/ArcanistStackWorkflow.php
@@ -774,6 +774,13 @@ EOTEXT
           'Build failures:');
         $prompt = pht('Land revision anyway, despite build failures?');
         break;
+      case 'preparing':
+        $message = pht(
+          'Harbormaster is still preparing build for the active diff for this '.
+          'revision. ');
+        $prompt = pht('Land revision anyway, despite build being prepared for '.
+                      'execution?');
+        break;
       default:
         // If we don't recognize the status, just bail.
         return false;


### PR DESCRIPTION
Preparing state was ignored by `arc stack`, it is essentially state where tests are not yet started