### PR TITLE
[arc flow] Change how we detect base commit, from greping git log for Differential Revision to asking phabricator about Base commit

### DIFF
--- a/src/flow/field/ICFlowChangedLinesField.php
+++ b/src/flow/field/ICFlowChangedLinesField.php
@@ -19,8 +19,8 @@ final class ICFlowChangedLinesField extends ICFlowField {
     $git = $workspace->getGitAPI();
     foreach ($workspace->getFeatures() as $branch => $feature) {
       $local_diff = $feature->getHead()->getHeadDiff();
-      if ($feature->getRevisionFirstCommit()) {
-         $local_diff = $git->getAPI()->getFullGitDiff($feature->getRevisionFirstCommit()."^", $feature->getHead()->getObjectName());
+      if ($feature->getActiveDiffID()) {
+         $local_diff = $git->getAPI()->getFullGitDiff($feature->getRevisionBaseCommit(), $feature->getHead()->getObjectName());
       }
       if ($local_diff) {
         $md5 = md5($local_diff);

--- a/src/flow/field/ICFlowHashField.php
+++ b/src/flow/field/ICFlowHashField.php
@@ -29,7 +29,7 @@ final class ICFlowHashField extends ICFlowField {
   public function getValues(ICFlowFeature $feature) {
     $hash = $feature->getHead()->getObjectName();
     $local_diff = $feature->getHead()->getHeadDiff();
-    $remote_diff = $feature->getActiveDiff();
+    $remote_diff = $feature->getRawActiveDiff();
     $values = array(
       'hash' => $hash,
       'stale' => false,

--- a/src/flow/field/ICFlowStatusField.php
+++ b/src/flow/field/ICFlowStatusField.php
@@ -8,7 +8,7 @@ final class ICFlowStatusField extends ICFlowField {
 
   public function getSummary() {
     return pht(
-      'The review status or queue status of the differential revision '.
+      'The review status of the differential revision '.
       'associated with HEAD of the branch.');
   }
 
@@ -20,19 +20,6 @@ final class ICFlowStatusField extends ICFlowField {
 
   public function getValues(ICFlowFeature $feature) {
     $status = $feature->getRevisionStatusName();
-    $submissions = $feature->getSearchAttachment('queue-submissions');
-    if ($submissions) {
-      $submissions = igroup($submissions, 'status');
-      if (idx($submissions, 'applied')) {
-        if ($status !== 'Closed') {
-          $status = 'Queue Landing';
-        }
-      } else if (idx($submissions, 'queued')) {
-        $status = 'In Queue';
-      } else if (idx($submissions, 'rejected')) {
-        $status = 'Queue Rejected';
-      }
-    }
     $color = idx(array(
       'Closed'          => 'cyan',
       'Needs Review'    => 'magenta',

--- a/src/flow/model/ICFlowFeature.php
+++ b/src/flow/model/ICFlowFeature.php
@@ -6,9 +6,9 @@ final class ICFlowFeature extends Phobject {
   private $differentialCommitMessage = null;
   // commit sha which has differential commit message, essentially where
   // differential revision starts
-  private $revisionFirstCommit = null;
   private $revision;
   private $search;
+  private $rawActiveDiff;
   private $activeDiff;
 
   private function __construct() {}
@@ -49,7 +49,6 @@ final class ICFlowFeature extends Phobject {
         $log->getMetadata('message'));
       if ($message->getRevisionID() != null) {
         $feature->differentialCommitMessage = $message;
-        $feature->revisionFirstCommit = $log->getCommitHash();
         break;
       }
     }
@@ -96,8 +95,18 @@ final class ICFlowFeature extends Phobject {
     return $this->differentialCommitMessage->getRevisionID();
   }
 
-  public function getRevisionFirstCommit() {
-    return $this->revisionFirstCommit;
+  public function getActiveDiffField($index, $default = null) {
+    if (!$this->activeDiff) {
+      return null;
+    }
+    return idx($this->activeDiff, $index, $default);
+  }
+
+  public function getRevisionBaseCommit() {
+    if ($this->activeDiff == null) {
+      throw new Exception('Active diff is not attached! Cannot get base commit');
+    }
+    return $this->getActiveDiffField('sourceControlBaseRevision');
   }
 
   public function getSearchField($index, $default = null) {
@@ -127,6 +136,15 @@ final class ICFlowFeature extends Phobject {
 
   public function getHead() {
     return $this->head;
+  }
+
+  public function attachRawActiveDiff($diff) {
+    $this->rawActiveDiff = $diff;
+    return $this;
+  }
+
+  public function getRawActiveDiff() {
+    return $this->rawActiveDiff;
   }
 
   public function attachActiveDiff($diff) {

--- a/src/flow/model/ICFlowFeature.php
+++ b/src/flow/model/ICFlowFeature.php
@@ -7,7 +7,6 @@ final class ICFlowFeature extends Phobject {
   // commit sha which has differential commit message, essentially where
   // differential revision starts
   private $revision;
-  private $search;
   private $rawActiveDiff;
   private $activeDiff;
 
@@ -107,23 +106,6 @@ final class ICFlowFeature extends Phobject {
       throw new Exception('Active diff is not attached! Cannot get base commit');
     }
     return $this->getActiveDiffField('sourceControlBaseRevision');
-  }
-
-  public function getSearchField($index, $default = null) {
-    if (!$this->search) {
-      return $default;
-    }
-    return idx($this->search, $index, $default);
-  }
-
-  public function attachSearchData(array $search = null) {
-    $this->search = $search;
-    return $this;
-  }
-
-  public function getSearchAttachment($name) {
-    $attachments = $this->getSearchField('attachments', array());
-    return idx($attachments, $name);
   }
 
   public function getDifferentialCommitMessage() {

--- a/src/flow/workflow/ICArcanistWorkflow.php
+++ b/src/flow/workflow/ICArcanistWorkflow.php
@@ -4,7 +4,7 @@
  * Base class that workflows within rIC should extend from.
  *
  * It mainly eases the process of collecting information about a users remote
- * and local data, like users revisions, diffs, branches and queue submissions.
+ * and local data, like users revisions, diffs, branches.
  * It's very common to need to inspect both the local and remote state of
  * these things, but usually also relatively tedious.
  *
@@ -39,21 +39,6 @@ abstract class ICArcanistWorkflow extends ArcanistWorkflow {
 
   public function requiresRepositoryAPI() {
     return true;
-  }
-
-  protected function searchMethodForID($method, $id) {
-    $rval = $this->getConduit()->callMethodSynchronous($method, array(
-      'constraints' => array(
-        'ids' => array((int)$id),
-      ),
-    ));
-    if (!idx($rval, 'data')) {
-      throw new ArcanistUsageException(pht(
-        'No results for id %s from %s.',
-        $id,
-        $method));
-    }
-    return head($rval['data']);
   }
 
   protected function getGitAPI() {

--- a/src/flow/workflow/ICArcanistWorkflow.php
+++ b/src/flow/workflow/ICArcanistWorkflow.php
@@ -95,7 +95,7 @@ abstract class ICArcanistWorkflow extends ArcanistWorkflow {
     if (!$feature || !$feature->getRevisionID()) {
       return false;
     }
-    $this->getFlow()->loadRevisions();
+    $this->getFlow()->loadRevisions()->loadActiveDiffs();
     return $feature;
   }
 

--- a/src/flow/workflow/ICCascadeWorkflow.php
+++ b/src/flow/workflow/ICCascadeWorkflow.php
@@ -122,7 +122,7 @@ EOTEXT
                "technique (rebase --onto)";
           $api->execxLocal('rebase --abort');
           list($err, $stdout, $stderr) = $this->rebaseOnto($branch_name,
-                            $feature->getRevisionFirstCommit().'^',
+                            $feature->getRevisionBaseCommit(),
                             $child_branch);
         }
       }


### PR DESCRIPTION
We used wrong assumption that `arc diff` is rewriting first commit in change it actually amends the last one. This break cascading rebase when rebase conflict happens and we try to use alternative rebase based on `rebase --onto`.