### PR TITLE
Reset to base revision if it is available when branch creation or commit creation is disabled

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -538,7 +538,15 @@ EOTEXT
         }
       }
       $new_branch = $this->createBranch($bundle, $has_base_revision);
+    // UBER CODE
+    } elseif ($has_base_revision) {
+      // try reseting to a base revision to properly apply change
+      if ($repository_api instanceof ArcanistGitAPI) {
+        $base_revision = $bundle->getBaseRevision();
+        $repository_api->execManualLocal("reset --hard %s", $base_revision);
+      }
     }
+    // UBER CODE END
     if (!$has_base_revision && $this->shouldApplyDependencies()) {
       $this->authenticateConduit(); // UBER CODE
       $this->applyDependencies($bundle);


### PR DESCRIPTION
When commit/branch creation is disabled phabricator jenkins plugin tries to apply changes on master and this causes issue with stacked changes. This should also solve issue with need to fetch refs from staging repositories before running `arc patch`.