### PR TITLE
Linting fixes for deprecated call

### DIFF
--- a/src/flow/workflow/ICTidyWorkflow.php
+++ b/src/flow/workflow/ICTidyWorkflow.php
@@ -125,7 +125,7 @@ EOTEXT
     if (!$skip_recover && $orphaned && $this->consoleConfirm(tsprintf(
         "The branches listed below:\n%s\nno longer have valid ".
         "upstream\n\n Attach these branches to 'master'?",
-        implode($orphaned, "\n")))) {
+        implode("\n", $orphaned)))) {
       foreach ($orphaned as $orphan) {
         $git->execxLocal(
           'branch --set-upstream-to=master %s',


### PR DESCRIPTION
Passing glue string after array is deprecated