### PR TITLE
Handle fatal error with uSSO enabled case when `arc patch` is used with `--arcbundle`

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -475,6 +475,13 @@ EOTEXT
           $try_encoding = $this->getRepositoryEncoding();
         } catch (ConduitClientException $e) {
           $try_encoding = null;
+        // UBER CODE
+        } catch (HTTPFutureHTTPResponseStatus $ex) {
+          if ($ex->getStatusCode() != 401) {
+            throw $ex;
+          }
+          $try_encoding = null;
+        // UBER CODE END
         }
       }
     }


### PR DESCRIPTION
`--arcbundle` doesn't actually exercise authorization workflow because it doesn't need anything from Phabricator before this point and fails fatally when 401 status code from uSSO is returned, make it compatible with old behavior when auth errors were simply ignored