### PR TITLE
Open create jira issue in browser to keep similar to old behavior

### DIFF
--- a/src/uber/UberTask.php
+++ b/src/uber/UberTask.php
@@ -244,9 +244,11 @@ final class UberTask extends Phobject {
                   'description' => $description,
                 ));
             $issues[] = $jira_issue['key'];
+            $issue_url = sprintf(self::ISSUE_URL, $jira_issue['key']);
             $this->console
               ->writeOut(pht("Jira issue %s created\n",
-                  sprintf(self::ISSUE_URL, $jira_issue['key'])));
+                  $issue_url));
+            $this->openURIsInBrowser(array($issue_url));
             break;
           }
         }

--- a/src/uber/UberTask.php
+++ b/src/uber/UberTask.php
@@ -246,8 +246,7 @@ final class UberTask extends Phobject {
             $issues[] = $jira_issue['key'];
             $issue_url = sprintf(self::ISSUE_URL, $jira_issue['key']);
             $this->console
-              ->writeOut(pht("Jira issue %s created\n",
-                  $issue_url));
+              ->writeOut(pht("Jira issue %s created\n", $issue_url));
             $this->openURIsInBrowser(array($issue_url));
             break;
           }


### PR DESCRIPTION
Some users actually want to make edits in web, so to break flow as little as possible - after task is created - it is immediately opened in browser