### PR TITLE
[Autoland] Prompt user to tag with #autoland upon revision creation

### DIFF
--- a/src/configuration/ArcanistSettings.php
+++ b/src/configuration/ArcanistSettings.php
@@ -281,6 +281,16 @@ final class ArcanistSettings extends Phobject {
           'If true, arc will query jira for issues and display it for user selection'),
         'default' => true,
       ),
+      'uber.differential.autoland-prompt' => array(
+        'type' => 'string',
+        'help' => pht('Set to default-yes / default-no for tagging change with #autoland'),
+        'default' => null,
+      ),
+      'uber.differential.autoland-prompt-message' => array(
+        'type' => 'string',
+        'help' => pht('Message to show in prompt for #autoland'),
+        'default' => 'Autoland after builds pass and reviewers approve?',
+      ),
     );
   }
 


### PR DESCRIPTION
This change adds a prompt to the user during a new revision creation to tag it with #autoland . Handles various cases to skip this prompt as well. It is gated behind the config flag `uber.differential.autoland-prompt`

Some screenshots in action:
![Screen Shot 2021-06-01 at 3 07 03 PM](https://user-images.githubusercontent.com/291148/120398109-72dca580-c2ee-11eb-964d-d99aa81d9209.png)
![Screen Shot 2021-06-01 at 3 07 08 PM](https://user-images.githubusercontent.com/291148/120398110-72dca580-c2ee-11eb-838f-e2348b44b449.png)
![Screen Shot 2021-06-01 at 3 26 22 PM](https://user-images.githubusercontent.com/291148/120398112-73753c00-c2ee-11eb-9d2a-2f61213d1d72.png)
