### PR TITLE
Check for empty diff summary in autoland tagging workflow

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -2241,9 +2241,12 @@ EOTEXT
     }
 
     // Skip if summary already has #autoland
-    $hasAutolandTag = (bool)preg_match('/#autoland/i', $revision['fields']['summary']);
-    if ($hasAutolandTag) {
-      return false;
+    $summary = idx($revision['fields'], 'summary');
+    if ($summary !== null) {
+      $hasAutolandTag = (bool)preg_match('/#autoland/i', $summary);
+      if ($hasAutolandTag) {
+        return false;
+      }
     }
 
     // Skip if author is member of autoland project


### PR DESCRIPTION
Fix the below stacktrace
```
ERROR 8: Undefined index: summary at [/usr/local/Cellar/arcanist/tip/arcanist/src/workflow/ArcanistDiffWorkflow.php:2244]
arcanist
  #0 ArcanistDiffWorkflow::shouldTagWithAutoland(array) called at [<arcanist>/src/workflow/ArcanistDiffWorkflow.php:486]
  #1 ArcanistDiffWorkflow::run() called at [<arcanist>/scripts/arcanist.php:394]
```