### PR TITLE
Try to fetch base ref explicitly before fetch all

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -511,17 +511,18 @@ EOTEXT
           "<bg:blue>** %s **</bg> %s\n",
           pht('INFO'),
           pht('Base commit is not in local repository; trying to fetch.'));
-        $repository_api->execManualLocal('fetch --quiet --all');
+        // UBER CODE
+        $this->authenticateConduit();
+        $this->pullFromAllRemotesUntilFound($bundle->getBaseRevision());
         $has_base_revision = $repository_api->hasLocalCommit(
           $bundle->getBaseRevision());
-        // UBER CODE
         if (!$has_base_revision) {
-          $this->authenticateConduit();
-          $this->pullFromAllRemotesUntilFound($bundle->getBaseRevision());
+          // UBER CODE
+          $repository_api->execManualLocal('fetch --quiet --all');
           $has_base_revision = $repository_api->hasLocalCommit(
             $bundle->getBaseRevision());
         }
-        // UBER CODE
+
       }
     }
 
@@ -1298,7 +1299,7 @@ EOTEXT
       $remotes = array_merge($remotes, array_filter(explode(PHP_EOL, $stdin)));
     }
     foreach ($remotes as $remote) {
-      $repository_api->execManualLocal('fetch %s %s', $remote, $hash);
+      $repository_api->execManualLocal('fetch --no-tags --depth=1 %s %s', $remote, $hash);
       if ($repository_api->hasLocalCommit($hash)) {
         break;
       }

--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -1299,7 +1299,7 @@ EOTEXT
       $remotes = array_merge($remotes, array_filter(explode(PHP_EOL, $stdin)));
     }
     foreach ($remotes as $remote) {
-      $repository_api->execManualLocal('fetch --no-tags --depth=1 %s %s', $remote, $hash);
+      $repository_api->execManualLocal('fetch --depth=1 %s %s', $remote, $hash);
       if ($repository_api->hasLocalCommit($hash)) {
         break;
       }

--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -1299,7 +1299,7 @@ EOTEXT
       $remotes = array_merge($remotes, array_filter(explode(PHP_EOL, $stdin)));
     }
     foreach ($remotes as $remote) {
-      $repository_api->execManualLocal('fetch --depth=1 %s %s', $remote, $hash);
+      $repository_api->execManualLocal('fetch %s %s', $remote, $hash);
       if ($repository_api->hasLocalCommit($hash)) {
         break;
       }


### PR DESCRIPTION
When a diff has a base not present in the repository, try to fetch the specific base ref from staging and origin first before trying the potentially expensive 'git fetch --all'.