### PR TITLE
Fetch using depth=1 with "--uber-use-staging-git-tags"

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -1261,7 +1261,7 @@ EOTEXT
     $base_tag = $this->uberRefProvider->getBaseRefName($prefix, $id);
     echo pht('Fetching base ref "%s" from staging remote', $base_tag)."\n";
     $err = phutil_passthru(
-          'git fetch --tag -n %s %s',
+          'git fetch --no-tags --depth=1 %s %s',
           $staging_uri,
           $base_tag);
 
@@ -1269,7 +1269,7 @@ EOTEXT
       $base_tag = "{$prefix}/base/{$id}";
       echo pht('Fetching base tag "%s" from staging remote', $base_tag)."\n";
       $err = phutil_passthru(
-            'git fetch --tag -n %s %s',
+            'git fetch --no-tags --depth=1 %s %s',
             $staging_uri,
             $base_tag);
       if ($err) {


### PR DESCRIPTION
- Use --depth=1 when fetching base ref from staging repository
- Remove '--tag' flag which is not applicable to 'git fetch'