### PR TITLE
Revert use of --depth=1 in --uber-use-staging-git-tags

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -1261,7 +1261,7 @@ EOTEXT
     $base_tag = $this->uberRefProvider->getBaseRefName($prefix, $id);
     echo pht('Fetching base ref "%s" from staging remote', $base_tag)."\n";
     $err = phutil_passthru(
-          'git fetch --no-tags --depth=1 %s %s',
+          'git fetch --no-tags %s %s',
           $staging_uri,
           $base_tag);
 
@@ -1269,7 +1269,7 @@ EOTEXT
       $base_tag = "{$prefix}/base/{$id}";
       echo pht('Fetching base tag "%s" from staging remote', $base_tag)."\n";
       $err = phutil_passthru(
-            'git fetch --no-tags --depth=1 %s %s',
+            'git fetch --no-tags %s %s',
             $staging_uri,
             $base_tag);
       if ($err) {


### PR DESCRIPTION
Further investigation has revealed this may have unintended side-effects. 