### PR TITLE
Fix unhandled exception for older php version

### DIFF
--- a/src/uber/UberTask.php
+++ b/src/uber/UberTask.php
@@ -121,7 +121,12 @@ final class UberTask extends Phobject {
       try {
         $issues = $this->getIssues();
       } catch (Throwable $e) {
-        $this->console->writeOut(pht("Something is wrong with jira, skipping...\n\n"));
+        $this->console->writeOut(
+          pht("Something is wrong with jira, skipping...\n\n"));
+        return array();
+      } catch (Exception $e) {
+        $this->console->writeOut(
+          pht("Something is wrong with jira, skipping...\n\n"));
         return array();
       }
       $for_search = array();

--- a/src/uber/UberTask.php
+++ b/src/uber/UberTask.php
@@ -120,11 +120,11 @@ final class UberTask extends Phobject {
       $issues = array();
       try {
         $issues = $this->getIssues();
-      } catch (Throwable $e) {
+      } catch (Exception $e) {
         $this->console->writeOut(
           pht("Something is wrong with jira, skipping...\n\n"));
         return array();
-      } catch (Exception $e) {
+      } catch (Throwable $e) {
         $this->console->writeOut(
           pht("Something is wrong with jira, skipping...\n\n"));
         return array();


### PR DESCRIPTION
Older operating systems provide php 5.6 which doesn't yet have Throwable as parent of Exception hence exception is not actually handled there