### PR TITLE
Prevent temp dir cleanup from causing command failure

### DIFF
--- a/src/workflow/ArcanistBulkPatchWorkflow.php
+++ b/src/workflow/ArcanistBulkPatchWorkflow.php
@@ -274,7 +274,11 @@ EOTEXT
       }
     }
     finally {
-      Filesystem::remove($repoPath);
+      try {
+        Filesystem::remove($repoPath);
+      } catch (Exception $ex) {
+        $this->writeWarn(pht('WARNING'), pht('Failed to cleanup temporary git directory: %s', $ex));
+      }
     }
 
     return $diffPatchMap;

--- a/src/workflow/ArcanistBulkPatchWorkflow.php
+++ b/src/workflow/ArcanistBulkPatchWorkflow.php
@@ -278,6 +278,8 @@ EOTEXT
         Filesystem::remove($repoPath);
       } catch (Exception $ex) {
         $this->writeWarn(pht('WARNING'), pht('Failed to cleanup temporary git directory: %s', $ex));
+      } catch (Throwable $ex) {
+        $this->writeWarn(pht('WARNING'), pht('Failed to cleanup temporary git directory: %s', $ex));
       }
     }
 


### PR DESCRIPTION
Prevent failure of Filesystem::remove when cleaning up the temporary directory causing the entire command to fail. 
