### PR TITLE
Do not fetch staging refs if we already have base hash in repository

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -435,18 +435,18 @@ EOTEXT
             $param);
           break;
         case self::SOURCE_DIFF:
+          $bundle = $this->loadDiffBundleFromConduit(
+             $this->getConduit(),
+             $param);
           if ($this->shouldMergeUsingStagingGitTag()) {
-            $bundle = $this->loadDiffBundleFromConduit(
-              $this->getConduit(),
-              $param);
             $this->mergeBranchFromStagingArea($param, $bundle);
             return 0;
           } elseif ($this->shouldUseStagingGitTags()) {
+            $repository_api = $this->getRepositoryAPI();
+            if (!$repository_api->hasLocalCommit($bundle->getBaseRevision())) {
               $this->pullBaseTagFromStagingArea($param);
             }
-          $bundle = $this->loadDiffBundleFromConduit(
-            $this->getConduit(),
-            $param);
+          }
           break;
       }
     } catch (ConduitClientException $ex) {


### PR DESCRIPTION
`--uber-use-staging-git-tags` is always trying to fetch staging ref even if commit that ref is referring to is available in repository. Lets not do it if we have it in repository, this will save some roundtrip.