### PR TITLE
Display all projects instead of top 3

### DIFF
--- a/src/uber/UberTask.php
+++ b/src/uber/UberTask.php
@@ -142,12 +142,11 @@ final class UberTask extends Phobject {
       $for_search[] = self::SKIP_MSG;
       // general jira task creation
       $for_search[] = self::CREATE_MSG;
-      // get top 3 projects to display
+      // sort projects by number of tasks
       uasort($projects,
         function ($v1, $v2) {
           return $v2['tasks'] - $v1['tasks'];
       });
-      $projects = array_slice($projects, 0, 3);
       // attach create task in project XXX to the list
       foreach ($projects as $project => $v) {
         $for_search[] = sprintf(self::CREATE_IN_PROJ_MSG, $project);


### PR DESCRIPTION
Limiting the view to only top 3 projects is too restrictive given how much time interactive issue creation saves.

Another problem with the current approach is that starting a new project or transferring teams will cause your new active project to be low rank and likely missing from the issue creation list for a while until you get more tasks.