### PR TITLE
Fetch staging ref by ref first before fetching by hash whenever we know diff ID

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -513,16 +513,20 @@ EOTEXT
           pht('Base commit is not in local repository; trying to fetch.'));
         // UBER CODE
         $this->authenticateConduit();
-        $this->pullFromAllRemotesUntilFound($bundle->getBaseRevision());
+        $this->pullBaseTagFromStagingArea($param);
         $has_base_revision = $repository_api->hasLocalCommit(
           $bundle->getBaseRevision());
         if (!$has_base_revision) {
-          // UBER CODE
-          $repository_api->execManualLocal('fetch --quiet --all');
+          $this->pullFromAllRemotesUntilFound($bundle->getBaseRevision());
           $has_base_revision = $repository_api->hasLocalCommit(
             $bundle->getBaseRevision());
+          if (!$has_base_revision) {
+            $repository_api->execManualLocal('fetch --quiet --all');
+            $has_base_revision = $repository_api->hasLocalCommit(
+              $bundle->getBaseRevision());
+          }
         }
-
+        // UBER CODE END
       }
     }
 

--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -513,9 +513,11 @@ EOTEXT
           pht('Base commit is not in local repository; trying to fetch.'));
         // UBER CODE
         $this->authenticateConduit();
-        $this->pullBaseTagFromStagingArea($param);
-        $has_base_revision = $repository_api->hasLocalCommit(
-          $bundle->getBaseRevision());
+        if ($source == self::SOURCE_DIFF) {
+          $this->pullBaseTagFromStagingArea($param);
+          $has_base_revision = $repository_api->hasLocalCommit(
+            $bundle->getBaseRevision());
+        }
         if (!$has_base_revision) {
           $this->pullFromAllRemotesUntilFound($bundle->getBaseRevision());
           $has_base_revision = $repository_api->hasLocalCommit(


### PR DESCRIPTION
Fetching by ref is slow on staging machines serving large repositories