### PR TITLE
Downcase `Git` to make sure identical casing is used during local and remote operations

### DIFF
--- a/src/land/ArcanistGitLandEngine.php
+++ b/src/land/ArcanistGitLandEngine.php
@@ -908,7 +908,7 @@ class ArcanistGitLandEngine
     $this->writeInfo(
       pht('REMOTE'),
       pht(
-        'Using remote "%s", the default remote under Git.',
+        'Using remote "%s", the default remote under git.',
         $remote));
 
     return $remote;


### PR DESCRIPTION
Different casing constantly bother me:
![image](https://user-images.githubusercontent.com/1893606/136791601-e769fd2b-dde6-4d08-9d9c-494176f999b3.png)
