### PR TITLE
[arc patch] No need for customized pulling of staging refs, it is always done below

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -441,11 +441,6 @@ EOTEXT
           if ($this->shouldMergeUsingStagingGitTag()) {
             $this->mergeBranchFromStagingArea($param, $bundle);
             return 0;
-          } elseif ($this->shouldUseStagingGitTags()) {
-            $repository_api = $this->getRepositoryAPI();
-            if (!$repository_api->hasLocalCommit($bundle->getBaseRevision())) {
-              $this->pullBaseTagFromStagingArea($param);
-            }
           }
           break;
       }


### PR DESCRIPTION
Removing duplicate functionality, will also slightly improve patching speed