### PR TITLE
Remove final from private functions for PHP 8 compatibility

### DIFF
--- a/src/lint/engine/ArcanistLintEngine.php
+++ b/src/lint/engine/ArcanistLintEngine.php
@@ -284,7 +284,7 @@ abstract class ArcanistLintEngine extends Phobject {
     return ArcanistLintSeverity::isAtLeastAsSevere($severity, $minimum);
   }
 
-  final private function shouldUseCache(
+  private function shouldUseCache(
     $cache_granularity,
     $repository_version) {
 
@@ -323,7 +323,7 @@ abstract class ArcanistLintEngine extends Phobject {
     return $this;
   }
 
-  final private function isRelevantMessage(ArcanistLintMessage $message) {
+  private function isRelevantMessage(ArcanistLintMessage $message) {
     // When a user runs "arc lint", we default to raising only warnings on
     // lines they have changed (errors are still raised anywhere in the
     // file). The list of $changed lines may be null, to indicate that the

--- a/src/lint/linter/ArcanistLinter.php
+++ b/src/lint/linter/ArcanistLinter.php
@@ -305,7 +305,7 @@ abstract class ArcanistLinter extends Phobject {
    * @param  list<string>
    * @return list<string>
    */
-  final private function filterPaths(array $paths) {
+  private function filterPaths(array $paths) {
     $engine = $this->getEngine();
 
     $keep = array();

--- a/src/unit/engine/phutil/PhutilTestCase.php
+++ b/src/unit/engine/phutil/PhutilTestCase.php
@@ -407,7 +407,7 @@ abstract class PhutilTestCase extends Phobject {
    *
    * @task internal
    */
-  final private function failTest($reason) {
+  private function failTest($reason) {
     $this->resultTest(ArcanistUnitTestResult::RESULT_FAIL, $reason);
   }
 
@@ -420,7 +420,7 @@ abstract class PhutilTestCase extends Phobject {
    *
    * @task internal
    */
-  final private function passTest($reason) {
+  private function passTest($reason) {
     $this->resultTest(ArcanistUnitTestResult::RESULT_PASS, $reason);
   }
 
@@ -432,12 +432,12 @@ abstract class PhutilTestCase extends Phobject {
    * @return void
    * @task internal
    */
-  final private function skipTest($reason) {
+  private function skipTest($reason) {
     $this->resultTest(ArcanistUnitTestResult::RESULT_SKIP, $reason);
   }
 
 
-  final private function resultTest($test_result, $reason) {
+  private function resultTest($test_result, $reason) {
     $coverage = $this->endCoverage();
 
     $result = new ArcanistUnitTestResult();
@@ -552,7 +552,7 @@ abstract class PhutilTestCase extends Phobject {
   /**
    * @phutil-external-symbol function xdebug_start_code_coverage
    */
-  final private function beginCoverage() {
+  private function beginCoverage() {
     if (!$this->enableCoverage) {
       return;
     }
@@ -565,7 +565,7 @@ abstract class PhutilTestCase extends Phobject {
    * @phutil-external-symbol function xdebug_get_code_coverage
    * @phutil-external-symbol function xdebug_stop_code_coverage
    */
-  final private function endCoverage() {
+  private function endCoverage() {
     if (!$this->enableCoverage) {
       return;
     }
@@ -617,7 +617,7 @@ abstract class PhutilTestCase extends Phobject {
     return $coverage;
   }
 
-  final private function assertCoverageAvailable() {
+  private function assertCoverageAvailable() {
     if (!function_exists('xdebug_start_code_coverage')) {
       throw new Exception(
         pht("You've enabled code coverage but XDebug is not installed."));
@@ -674,7 +674,7 @@ abstract class PhutilTestCase extends Phobject {
    *
    * @return map
    */
-  final private static function getCallerInfo() {
+  private static function getCallerInfo() {
     $callee = array();
     $caller = array();
     $seen = false;

--- a/src/workflow/ArcanistWorkflow.php
+++ b/src/workflow/ArcanistWorkflow.php
@@ -584,7 +584,7 @@ abstract class ArcanistWorkflow extends Phobject {
     return $this->workingDirectory;
   }
 
-  final private function setParentWorkflow($parent_workflow) {
+  private function setParentWorkflow($parent_workflow) {
     $this->parentWorkflow = $parent_workflow;
     return $this;
   }
@@ -1202,7 +1202,7 @@ abstract class ArcanistWorkflow extends Phobject {
     ));
   }
 
-  final private function loadBundleFromConduit(
+  private function loadBundleFromConduit(
     ConduitClient $conduit,
     $params) {
 


### PR DESCRIPTION
This combination does not make sense and PHP 8 errors with:

```
Private methods cannot be final as they are never overridden by other classes
```

Thus remove the redundant final from all such functions.