### PR TITLE
make array_mergev function compatible with PHP8.0

### DIFF
--- a/src/utils/utils.php
+++ b/src/utils/utils.php
@@ -876,7 +876,7 @@ function array_mergev(array $arrayv) {
     }
   }
 
-  return call_user_func_array('array_merge', $arrayv);
+  return call_user_func_array('array_merge', array_values($arrayv));
 }
 
 


### PR DESCRIPTION
This fixes the following error:
```
EXCEPTION: (ArgumentCountError) array_merge() does not accept unknown named parameters at [<arcanist>/src/utils/utils.php:879]
```