### PR TITLE
bypass confirmation if non-tty and nointeractive is set

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -1063,10 +1063,11 @@ EOTEXT
               "\n\n  $ %s\n",
               'svn propset svn:mime-type application/octet-stream <filename>'));
         } else {
+          $skip_confirmation = !$this->isTTY() && $this->getArgument('nointeractive');
           $confirm = $byte_warning.' '.pht(
             "If the file is not a text file, you can mark it 'binary'. ".
             "Mark this file as 'binary' and continue?");
-          if (phutil_console_confirm($confirm)) {
+          if ($skip_confirmation || phutil_console_confirm($confirm)) {
             $change->convertToBinaryChange($repository_api);
           } else {
             throw new ArcanistUsageException(
@@ -2160,6 +2161,17 @@ EOTEXT
   }
 
   // UBER CODE
+
+  // Returns true if TTY environment, else false
+  private function isTTY() {
+    $is_tty = true;
+    try {
+      phutil_console_require_tty();
+    } catch (PhutilConsoleStdinNotInteractiveException $e) {
+      $is_tty = false;
+    }
+    return $is_tty;
+  }
 
   // Common checks before showing interactive prompts for user input
   private function commonPrePromptChecks() {


### PR DESCRIPTION
**Previous behavior**: 
`arc diff --nointeractive` will still prompt the user when there are large files in the diff (even though `--nointeractive` is set). 

**New behavior**: 
`arc diff --nointeractive` will no longer prompt the user, as long as we're in a non-TTY environment (for example, CI).

---

Required for GitHub migration, as our github-synchronizer buildkite job needs to create the revision from the GitHub PullRequest (even if there are large files). 