### PR TITLE
php-8.2-upgrade for arcanist

### DIFF
--- a/src/configuration/ArcanistConfigurationManager.php
+++ b/src/configuration/ArcanistConfigurationManager.php
@@ -258,7 +258,7 @@ final class ArcanistConfigurationManager extends Phobject {
   }
 
   public function getUserConfigurationFileLocation() {
-    if (strlen($this->customArcrcFilename)) {
+    if ($this->customArcrcFilename !== null) {
       return $this->customArcrcFilename;
     }
 

--- a/src/parser/ArcanistBundle.php
+++ b/src/parser/ArcanistBundle.php
@@ -639,8 +639,7 @@ final class ArcanistBundle extends Phobject {
     $old_path = $change->getOldPath();
     $type = $change->getType();
 
-    if (!strlen($old_path) ||
-        $type == ArcanistDiffChangeType::TYPE_ADD) {
+    if ($old_path === '' || $type == ArcanistDiffChangeType::TYPE_ADD) {
       $old_path = null;
     }
 

--- a/src/parser/ArcanistDiffParser.php
+++ b/src/parser/ArcanistDiffParser.php
@@ -217,7 +217,7 @@ final class ArcanistDiffParser extends Phobject {
       $line = $this->nextLine();
     }
 
-    if (strlen($message)) {
+    if ($message !== null && strlen($message)) {
       // If we found a message during pre-parse steps, add it to the resulting
       // changes here.
       $change = $this->buildChange(null)
@@ -918,11 +918,11 @@ final class ArcanistDiffParser extends Phobject {
       $hunk->setNewOffset($matches[3]);
 
       // Cover for the cases where length wasn't present (implying one line).
-      $old_len = idx($matches, 2);
+      $old_len = idx($matches, 2, '');
       if (!strlen($old_len)) {
         $old_len = 1;
       }
-      $new_len = idx($matches, 4);
+      $new_len = idx($matches, 4, '');
       if (!strlen($new_len)) {
         $new_len = 1;
       }
@@ -1039,7 +1039,7 @@ final class ArcanistDiffParser extends Phobject {
         $line = $this->nextNonemptyLine();
       }
 
-    } while (preg_match('/^@@ /', $line));
+    } while (($line !== null) && preg_match('/^@@ /', $line));
   }
 
   protected function buildChange($path = null) {

--- a/src/uber/UberTask.php
+++ b/src/uber/UberTask.php
@@ -51,7 +51,7 @@ final class UberTask extends Phobject {
       ->setFollowLocation(false)
       ->setTimeout(self::TIMEOUT)
       ->setMethod('POST')
-      ->addHeader('Authorization', "Bearer ${token}")
+      ->addHeader('Authorization', "Bearer {$token}")
       ->addHeader('Rpc-Caller', 'arcanist')
       ->addHeader('Rpc-Encoding', 'json')
       ->addHeader('Rpc-Procedure', 'ArcanistTheService::getIssues');

--- a/src/unit/renderer/ArcanistUnitConsoleRenderer.php
+++ b/src/unit/renderer/ArcanistUnitConsoleRenderer.php
@@ -12,7 +12,7 @@ final class ArcanistUnitConsoleRenderer extends ArcanistUnitRenderer {
 
     $test_name = $result->getName();
     $test_namespace = $result->getNamespace();
-    if (strlen($test_namespace)) {
+    if ($test_namespace != null && strlen($test_namespace)) {
       $test_name = $test_namespace.'::'.$test_name;
     }
 
@@ -65,8 +65,9 @@ final class ArcanistUnitConsoleRenderer extends ArcanistUnitRenderer {
       50   => "<fg:green>%s</fg><fg:yellow>{$star}</fg> ",
       200  => '<fg:green>%s</fg>  ',
       500  => '<fg:yellow>%s</fg>  ',
-      INF  => '<fg:red>%s</fg>  ',
     );
+
+    $least_acceptable = '<fg:red>%s</fg>  ';
 
     $milliseconds = $seconds * 1000;
     $duration = $this->formatTime($seconds);
@@ -75,7 +76,7 @@ final class ArcanistUnitConsoleRenderer extends ArcanistUnitRenderer {
         return phutil_console_format($formatting, $duration);
       }
     }
-    return phutil_console_format(end($acceptableness), $duration);
+    return phutil_console_format($least_acceptable, $duration);
   }
 
   private function formatTime($seconds) {

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -837,7 +837,7 @@ EOTEXT
       $this->revisionID = $revision_id;
 
       $revision['message'] = $this->getArgument('message');
-      if (!strlen($revision['message'])) {
+      if ($revision['message'] === null) {
         $update_messages = $this->readScratchJSONFile('update-messages.json');
 
         $update_messages[$revision_id] = $this->getUpdateMessage(
@@ -2391,9 +2391,12 @@ EOTEXT
     if ($template == '') {
       $comments = $this->getDefaultUpdateMessage();
 
+      $comments = phutil_string_cast($comments);
+      $comments = rtrim($comments);
+
       $template = sprintf(
         "%s\n\n# %s\n#\n# %s\n# %s\n#\n# %s\n#  $ %s\n\n",
-        rtrim($comments),
+        $comments,
         pht(
           'Updating %s: %s',
           "D{$fields['revisionID']}",
@@ -2930,7 +2933,7 @@ EOTEXT
    * @task diffprop
    */
   private function updateLintDiffProperty() {
-    if (strlen($this->excuses['lint'])) {
+    if ($this->excuses['lint'] !== null) {
       $this->updateDiffProperty(
         'arc:lint-excuse',
         json_encode($this->excuses['lint']));
@@ -2954,7 +2957,7 @@ EOTEXT
    * @task diffprop
    */
   private function updateUnitDiffProperty() {
-    if (strlen($this->excuses['unit'])) {
+    if ($this->excuses['unit'] !== null) {
       $this->updateDiffProperty('arc:unit-excuse',
         json_encode($this->excuses['unit']));
     }

--- a/src/workflow/ArcanistWorkflow.php
+++ b/src/workflow/ArcanistWorkflow.php
@@ -2066,7 +2066,7 @@ abstract class ArcanistWorkflow extends Phobject {
     $map = $this->getModernCommonDictionary($map);
 
     $details = idx($map, 'userData');
-    if (strlen($details)) {
+    if ($details !== null && strlen($details)) {
       $map['details'] = (string)$details;
     }
     unset($map['userData']);


### PR DESCRIPTION
Various methods require null check for string utils and others have been deprecated, Hence all changes are adding null check or replacing them with alternate option to upgrade it to PHP-8.2