### PR TITLE
Track lint execution for executeLinterOnPaths and executeDidLintOnPaths together

### DIFF
--- a/src/workflow/ArcanistUnitWorkflow.php
+++ b/src/workflow/ArcanistUnitWorkflow.php
@@ -170,6 +170,7 @@ EOTEXT
     $profiler = PhutilServiceProfiler::getInstance();
     $id = $profiler->beginServiceCall(array(
       'type' => 'unit',
+      'paths' => $paths,
       'engine' => get_class($this->engine),
     ));
 


### PR DESCRIPTION
There are two separate calls beginLintServiceCall and endLintServiceCall - one at [executeLinterOnPaths](https://github.com/uber/arcanist/pull/269/files#diff-c78fc11d2ae1d737f30dbb6a981b6e90e9ceb4fc0bb1f7c9cca4fff318875964L579) and another at [executeDidLintOnPaths](https://github.com/uber/arcanist/pull/269/files#diff-c78fc11d2ae1d737f30dbb6a981b6e90e9ceb4fc0bb1f7c9cca4fff318875964L599) it leads that the same event tracks twice with different duration for  executeLinterOnPaths and executeDidLintOnPaths

1. Make tracking lint execution for executeLinterOnPaths and executeDidLintOnPaths together
2. Add paths for unit tracking

For local testing copy changed arcanist to local dir /usr/local/Cellar/arcanist/tip/arcanist and run arc diff --trace 
