### PR TITLE
Move unit tracking to UberMultiTestEngine for tracking separate each multi engine

### DIFF
--- a/src/workflow/ArcanistUnitWorkflow.php
+++ b/src/workflow/ArcanistUnitWorkflow.php
@@ -167,16 +167,7 @@ EOTEXT
     }
     $this->engine->setEnableCoverage($enable_coverage);
 
-    $profiler = PhutilServiceProfiler::getInstance();
-    $id = $profiler->beginServiceCall(array(
-      'type' => 'unit',
-      'paths' => $paths,
-      'engine' => get_class($this->engine),
-    ));
-
     $results = $this->engine->run();
-
-    $profiler->endServiceCall($id, array());
 
     $this->validateUnitEngineResults($this->engine, $results);
 


### PR DESCRIPTION
Move unit tracking to UberMultiTestEngine for tracking each multi engine types - BazelTestEngine, CustomUnitTestEngine, ChecklistTestEngine, ExecuteCommandUnitTestEngine, etc.
Add as arguments (call the value paths for compatibility with previous changes at UberArcanistConfiguration for monorepos) unit.engine.command or build-system + target otherwise empty for tracking unit checks 

The related [PR#271](https://github.com/uber/arcanist/pull/271) for stable

Tested locally by moving changes to /usr/local/Cellar/arcanist/tip/arcanist and run arc unit --trace

Note: ios monorepo has UberModifiedMultiTestEngine in which need make similar changes as well.