### PR TITLE
Use rector to perform codemod to php8.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 # User extensions
 /externals/includes/*
 /src/extensions/*
+
+# 3rd party libs
+vendor/

--- a/README.md
+++ b/README.md
@@ -17,3 +17,24 @@ For more information about Phabricator, see http://phabricator.org/.
 **LICENSE**
 
 Arcanist is released under the Apache 2.0 license except as otherwise noted.
+
+## Use Rector to perform PHP code migrations
+
+1. Install composer: https://getcomposer.org/download/
+
+Composer is the php package manager, used to install codemod tooling.
+
+We use "rector" as our codemod tooling. Rector is a PHP code refactoring tool that allows you to automatically apply code changes to your codebase.
+
+2. Install composer dependencies using composer:
+
+```
+composer install
+```
+
+3. Include codemods you wish to run in the `./rector.php` file
+
+4. Run codemods
+
+Dry run using: `vendor/bin/rector process --dry-run`
+Apply codemods using: `vendor/bin/rector process`

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "rector/rector": "^1.2"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,136 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "eb58f3061bde78d58fa424c73947025f",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
+                "reference": "b5ae1b88f471d3fd4ba1aa0046234b5ca3776dd0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-11-28T22:13:23+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "1.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "40f9cf38c05296bd32f444121336a521a293fa61"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40f9cf38c05296bd32f444121336a521a293fa61",
+                "reference": "40f9cf38c05296bd32f444121336a521a293fa61",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.12.5"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/1.2.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-11-08T13:59:10+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,13 @@
+<?php
+
+use Rector\Config\RectorConfig;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
+
+return RectorConfig::configure()
+  ->withPaths([
+    __DIR__ . '/src',
+    __DIR__ . '/scripts',
+  ])
+  ->withRules([
+    ExplicitNullableParamTypeRector::class
+  ]);

--- a/src/flow/model/ICFlowFeature.php
+++ b/src/flow/model/ICFlowFeature.php
@@ -63,7 +63,7 @@ final class ICFlowFeature extends Phobject {
     return idx($this->revision, $index, $default);
   }
 
-  public function attachRevisionData(array $revision = null) {
+  public function attachRevisionData(?array $revision = null) {
     $this->revision = $revision;
     return $this;
   }
@@ -107,7 +107,7 @@ final class ICFlowFeature extends Phobject {
     return idx($this->search, $index, $default);
   }
 
-  public function attachSearchData(array $search = null) {
+  public function attachSearchData(?array $search = null) {
     $this->search = $search;
     return $this;
   }

--- a/src/uber/UberUSSO.php
+++ b/src/uber/UberUSSO.php
@@ -7,7 +7,7 @@ final class UberUSSO extends Phobject {
 
   public function enhanceConduitClient(
     $conduit,
-    HTTPFutureHTTPResponseStatus $status = null) {
+    ?HTTPFutureHTTPResponseStatus $status = null) {
 
     $tkn = null;
     if ($status != null) {

--- a/src/unit/ArcanistUnitTestResult.php
+++ b/src/unit/ArcanistUnitTestResult.php
@@ -111,7 +111,7 @@ final class ArcanistUnitTestResult extends Phobject {
    * "extra data" allows an implementation to store additional key/value
    * metadata along with the result of the test run.
    */
-  public function setExtraData(array $extra_data = null) {
+  public function setExtraData(?array $extra_data = null) {
     $this->extraData = $extra_data;
     return $this;
   }

--- a/src/unit/engine/ArcanistUnitTestEngine.php
+++ b/src/unit/engine/ArcanistUnitTestEngine.php
@@ -78,7 +78,7 @@ abstract class ArcanistUnitTestEngine extends Phobject {
     return $this->enableCoverage;
   }
 
-  final public function setRenderer(ArcanistUnitRenderer $renderer = null) {
+  final public function setRenderer(?ArcanistUnitRenderer $renderer = null) {
     $this->renderer = $renderer;
     return $this;
   }

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -2197,7 +2197,7 @@ EOTEXT
 
   // check and if necessary prompts to enter jira tasks
   private function attachJiraIssues(&$revision, array $diff_spec,
-    ArcanistDifferentialCommitMessage $message = null) {
+    ?ArcanistDifferentialCommitMessage $message = null) {
 
     if ($this->getArgument('nojira')) {
       return;


### PR DESCRIPTION
Applies [ExplicitNullableParamTypeRector](https://github.com/rectorphp/rector/blob/aff937886fc1bd7605bdc6f8d750174a15d890cf/docs/rector_rules_overview.md#php84) to the entire PHP codebase. Otherwise using PHP 8.4 breaks with deprecation warnings.

• This is the only breaking change when going from 8.3 -> 8.4
• This change is backwards compatible (works on php 8.3)