### PR TITLE
[arc] Updating compare-commit-to-revision to correctly determine if a local enlistment is needed

### DIFF
--- a/src/workflow/CompareCommitToRevisionWorkflow.php
+++ b/src/workflow/CompareCommitToRevisionWorkflow.php
@@ -51,7 +51,7 @@ EOTEXT
   }
 
   public function requiresWorkingCopy() {
-    return true;
+    return $this->useLocalEnlistment = $this->getArgument('use-local-enlistment');
   }
 
   public function requiresConduit() {
@@ -63,7 +63,7 @@ EOTEXT
   }
 
   public function requiresRepositoryAPI() {
-    return true;
+    return $this->useLocalEnlistment = $this->getArgument('use-local-enlistment');
   }
 
   public function getArguments() {

--- a/src/workflow/CompareCommitToRevisionWorkflow.php
+++ b/src/workflow/CompareCommitToRevisionWorkflow.php
@@ -51,7 +51,7 @@ EOTEXT
   }
 
   public function requiresWorkingCopy() {
-    return $this->useLocalEnlistment = $this->getArgument('use-local-enlistment');
+    return $this->getArgument('use-local-enlistment');
   }
 
   public function requiresConduit() {
@@ -63,7 +63,7 @@ EOTEXT
   }
 
   public function requiresRepositoryAPI() {
-    return $this->useLocalEnlistment = $this->getArgument('use-local-enlistment');
+    return $this->getArgument('use-local-enlistment');
   }
 
   public function getArguments() {


### PR DESCRIPTION
The logic that determines if a local enlistment is required wasn't updated when we changed the `compare-commit-to-revision` command to  work against conduit. 