### PR TITLE
[arc] Implement support for staging area remote override in .arcconfig

### DIFF
--- a/src/workflow/ArcanistDiffBasedWorkflow.php
+++ b/src/workflow/ArcanistDiffBasedWorkflow.php
@@ -72,6 +72,16 @@ abstract class ArcanistDiffBasedWorkflow extends ArcanistWorkflow {
             }
         }
 
+        // Using staging area remotes retrieved from Phabricator as-is will
+        // lead to arcanist pushing changes through Gitolite Adapter Config;
+        // we avoid that by introducing a custom field in .arcconfig to override
+        // the value set in Phabricator
+        $staging_uri_override =
+          $this->getConfigFromAnySource('uber.diff.staging.uri.override');
+        if ($staging_uri_override) {
+          $staging_uri = $staging_uri_override;
+        }
+
         $api = $this->getRepositoryAPI();
         if (!($api instanceof ArcanistGitAPI)) {
             $this->writeInfo(


### PR DESCRIPTION
As part of implementing [Git over gRPC](https://docs.google.com/document/d/1_MRgPzcLigDP4LMgG4FCMLdaxU8srbMVcpZH5ig7ynM/edit?pli=1&tab=t.0) we will change to Git remotes used for local checkout of Object Config repositories.

gitolite@config.uber.internal:<repository-name> will be changed to oc://<repository-name>

This breaks arc integration with staging area.

There are currently [29 Object Config repositories](https://code.uberinternal.com/P737097) using staging area. In these cases arc will push the staging tags using the remote specified in Phabricator. Since Phabricator does allow to use custom remote scheme, e.g. oc://. So it is not possible to just change staging area configs to use gRPC remote. The solution is this case is to introduce a new field in .arcconfig file (uber.diff.staging.uri.override) which will provide an override for the staging remote URL that arc can use for push tags. We do not expect many more repositories to onboard to staging are, so migrating 29 existing usages will be enough. Additionally, migration will not be automatic and users will be able to migrate off this new feature if necessary. 