### PR TITLE
[arc] Allow arc to query repository info for OC repositories using gR…

### DIFF
--- a/src/workflow/ArcanistWorkflow.php
+++ b/src/workflow/ArcanistWorkflow.php
@@ -38,6 +38,8 @@ abstract class ArcanistWorkflow extends Phobject {
   const COMMIT_DISABLE = 0;
   const COMMIT_ALLOW = 1;
   const COMMIT_ENABLE = 2;
+  const DEFAULT_OBJECTCONFIG_REMOTE_URL = 'gitolite@config.uber.internal:';
+  const GRPC_OBJECTCONFIG_REMOTE_URL = 'oc://';
 
   private $commitMode = self::COMMIT_DISABLE;
 
@@ -1863,6 +1865,11 @@ abstract class ArcanistWorkflow extends Phobject {
 
     $remote_uri = $this->getRepositoryAPI()->getRemoteURI();
     if ($remote_uri !== null) {
+      // Phabricator does not recognise custom gRPC remote scheme used by
+      // Object Config repositories; hence, we substitute the custom scheme
+      // with Gitolite one here
+      $remote_uri = str_replace(self::GRPC_OBJECTCONFIG_REMOTE_URL,
+        self::DEFAULT_OBJECTCONFIG_REMOTE_URL, $remote_uri);
       $query = array(
         'remoteURIs' => array($remote_uri),
       );


### PR DESCRIPTION
As part of implementing [Git over gRPC](https://docs.google.com/document/d/1_MRgPzcLigDP4LMgG4FCMLdaxU8srbMVcpZH5ig7ynM/edit?pli=1&tab=t.0) we will change to Git remotes used for local checkout of Object Config repositories.

[gitolite@config.uber.internal](mailto:gitolite@config.uber.internal): will be changed to oc://

This breaks arc integration with Phabricator.

arc CLI queries repository / revision information using repository remote. Since we will be using gRPC remotes going forward we need to implement a way for arc to work correctly with locally checked out repos. This is done by by substituting gRPC remote scheme (oc://) with the Gitolite remote used for OC repo ([gitolite@config.uber.internal](mailto:gitolite@config.uber.internal)).