### PR TITLE
Remove config that sets pre-push hook 

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -3293,18 +3293,6 @@ EOTEXT
       pht('PUSH STAGING'),
       pht('Pushing changes to staging area...'));
 
-    $push_flags = array();
-
-    $verify_config_name = 'uber.diff.git.push.verify';
-    $verify = $this->getConfigFromAnySource($verify_config_name);
-    if (version_compare($api->getGitVersion(), '1.8.2', '>=')) {
-      if ($verify) {
-        $push_flags[] = '--verify'; // default in git
-      } else {
-        $push_flags[] = '--no-verify';
-      }
-    }
-
     $refs = array();
 
     $remote = array(
@@ -3345,7 +3333,6 @@ EOTEXT
 
     $err = phutil_passthru(
       'git push %Ls -- %s %Ls',
-      $push_flags,
       $staging_uri,
       $ref_list);
 

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -3332,7 +3332,7 @@ EOTEXT
     }
 
     $err = phutil_passthru(
-      'git push %Ls -- %s %Ls',
+      'git push -- %s %Ls',
       $staging_uri,
       $ref_list);
 


### PR DESCRIPTION
Current: 
Repo owners who do not set "uber.diff.git.push.verify": true by default are not running pre-push hook on git push. 
This is not the default in git and just like all other git hooks, pre-push hooks should run. 

After this change:
"uber.diff.git.push.verify" config would not let you override running pre-push hooks. 