### PR TITLE
[stable branch] Implement automatically-convert-non-utf flag to automatically convert invalid UTF-8 sequences to binary.

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -455,6 +455,11 @@ EOTEXT
           'advice'    => pht('%s suppresses lint.', '--head'),
         ),
       ),
+      'automatically-convert-non-utf' => array(
+        'help' => pht(
+          'Automatically convert invalid UTF-8 sequences '.
+          'to binary.'),
+      ),
     );
 
     return $arguments;
@@ -1191,12 +1196,15 @@ EOBANNER;
       $file_list = '    '.implode("\n    ", $file_list);
       echo $file_list;
 
-      if (!phutil_console_confirm($confirm, $default_no = false)) {
-        throw new ArcanistUsageException(pht('Aborted workflow to fix UTF-8.'));
-      } else {
+      if (
+        $this->getArgument('automatically-convert-non-utf')
+        || phutil_console_confirm($confirm, $default_no = false)
+      ) {
         foreach ($utf8_problems as $change) {
           $change->convertToBinaryChange($repository_api);
         }
+      } else {
+        throw new ArcanistUsageException(pht('Aborted workflow to fix UTF-8.'));
       }
     }
 


### PR DESCRIPTION
I tested these changes locally with `arc diff` command.

Before changes:

1) I added invalid UTF-8 characters to the file:

`echo -e "\xC0\xAF Invalid UTF-8 characters" >> main.go`

2) I ran the command to attempt to create a diff:

`arc diff --nolint --nounit`

Output:

```
Provide explanation for skipping lint or press Enter to abort: skip


    Provide explanation for skipping unit tests or press Enter to abort: skip
Invalid Content Encoding (Non-UTF8)
This diff includes a file which is not valid UTF-8 (it has invalid byte
sequences). You can either stop this workflow and fix it, or continue. If you
continue, this file will be marked as binary.

You can learn more about how Phabricator handles character encodings (and how
to configure encoding settings and detect and correct encoding problems) by
reading 'User Guide: UTF-8 and Character Encoding' in the Phabricator
documentation.

    AFFECTED FILE
    src/.../main.go

    Do you want to mark this file as binary and continue? [Y/n] n

Usage Exception: Aborted workflow to fix UTF-8.
```


After changes:

1) I added invalid UTF-8 characters to the file:

`echo -e "\xC0\xAF Invalid UTF-8 characters" >> main.go`

2) I ran the command to attempt to create a diff:

`arc diff --nolint --nounit --automatically-convert-non-utf`

Output:

```
Provide explanation for skipping lint or press Enter to abort: skip


    Provide explanation for skipping unit tests or press Enter to abort: skip
Invalid Content Encoding (Non-UTF8)
This diff includes a file which is not valid UTF-8 (it has invalid byte
sequences). You can either stop this workflow and fix it, or continue. If you
continue, this file will be marked as binary.

You can learn more about how Phabricator handles character encodings (and how
to configure encoding settings and detect and correct encoding problems) by
reading 'User Guide: UTF-8 and Character Encoding' in the Phabricator
documentation.

    AFFECTED FILE
    src/.../main.goUploaded binary data for "main.go".
Uploaded binary data for "main.go".
Upload complete.
 PUSH STAGING  Pushing changes to staging area...
.........
Updating commit message...
Created a new Differential revision:
        Revision URI: https://.../D17005837

Included changes:
  M (bin) src/.../main.go
```

