### PR TITLE
[arc] Fixing false-positive cases in compare-commit-to-revision logic

### DIFF
--- a/src/lint/linter/xhpast/rules/ArcanistParentMemberReferenceXHPASTLinterRule.php
+++ b/src/lint/linter/xhpast/rules/ArcanistParentMemberReferenceXHPASTLinterRule.php
@@ -56,7 +56,7 @@ final class ArcanistParentMemberReferenceXHPASTLinterRule
           }
 
           $version_target = $this->version;
-          
+
           if ($version_target === null) {
             $version_target = phpversion();
           }

--- a/src/lint/linter/xhpast/rules/ArcanistSelfMemberReferenceXHPASTLinterRule.php
+++ b/src/lint/linter/xhpast/rules/ArcanistSelfMemberReferenceXHPASTLinterRule.php
@@ -43,7 +43,7 @@ final class ArcanistSelfMemberReferenceXHPASTLinterRule
           }
 
           $version_target = $this->version;
-          
+
           if (!$version_target) {
             $version_target = phpversion();
           }

--- a/src/lint/renderer/ArcanistConsoleLintRenderer.php
+++ b/src/lint/renderer/ArcanistConsoleLintRenderer.php
@@ -94,7 +94,7 @@ final class ArcanistConsoleLintRenderer extends ArcanistLintRenderer {
 
     $original = $message->getOriginalText();
     $original = phutil_string_cast($original);
-    
+
     $replacement = $message->getReplacementText();
 
     $line = $message->getLine();

--- a/src/workflow/CompareCommitToRevisionWorkflow.php
+++ b/src/workflow/CompareCommitToRevisionWorkflow.php
@@ -86,6 +86,13 @@ EOTEXT
           'The phab repo call-sign for the commit. e.g., GOCODVJ for go-code.'),
       ),
 
+      'repo-phid' => array(
+        'param' => 'phid',
+        'help' => pht(
+          'The repository PHID for the commit. Mutually exclusive with '.
+          'repo-call-sign parameter. e.g., PHID-REPO-44ztfu4siycp4tnveaoh'),
+      ),
+
       'keep-diffs' => array(
         'param' => 'directory',
         'help' => pht(
@@ -106,7 +113,6 @@ EOTEXT
           'specify if we to get commit information from a local git enlistment'.
           ' instead of getting the data from conduit.'),
       ),
-
     );
   }
 
@@ -123,6 +129,15 @@ EOTEXT
     }
 
 
+    if ($this->getArgument('repo-call-sign') &&
+        $this->getArgument('repo-phid')) {
+      echo pht(
+        'Error: You cannot specify both --repo-call-sign and --repo-phid. '.
+        'Please choose one or the other.'
+      );
+      return 1;
+    }
+
     // if a call-sign is specified, look up the repository PHID
     $repo_call_sign = $this->getArgument('repo-call-sign');
     if ($repo_call_sign) {
@@ -133,6 +148,9 @@ EOTEXT
                  $repo_call_sign);
         return 1;
       }
+    } else if ($this->getArgument('repo-phid')) {
+      // If the user specified a repo-phid, use that instead of the call-sign
+      $this->repositoryId = $this->getArgument('repo-phid');
     }
 
     // if a revision is not specified, get revision from the commit message
@@ -345,6 +363,7 @@ EOTEXT
     $changes = id(new ArcanistDiffParser())->parseDiff($text);
     ksort($changes);
     $val = ArcanistBundle::newFromChanges($changes)->toGitPatch();
+
     if (!$this->getArgument('no-normalize-line-numbers')) {
       $val = preg_replace('/^[<>]?\s*@@\s*[+-]\d*,\d*\s*[+-]\d*,\d*\s*@@$/m',
                           '@@ omitted-line-number @@', $val);
@@ -354,8 +373,15 @@ EOTEXT
     // matches. A "context line" in a patch is a line that starts with a space.
     $val = preg_replace('/^ .*$/m', '', $val);
 
-    // sometimes, the patches differ only by copy or rename.  Normlize them.
+    // sometimes, the patches differ only by copy or rename.  Normalize them.
     $val = preg_replace('/^(copy|rename)(.*)$/m', 'copy-or-rename$2', $val);
+
+    // remove text that says "No newline at end of file"
+    $val = preg_replace('/^\\\ No newline at end of file$/m', '', $val);
+
+    // strip out all blank lines
+    $val = trim(preg_replace("/(^[\r\n]|[\r\n]+)/", "\n", $val));
+
     return $val;
   }
 

--- a/src/workflow/CompareCommitToRevisionWorkflow.php
+++ b/src/workflow/CompareCommitToRevisionWorkflow.php
@@ -128,9 +128,10 @@ EOTEXT
       return 1;
     }
 
+    $repo_call_sign = $this->getArgument('repo-call-sign');
+    $this->repositoryId = $this->getArgument('repo-phid');
 
-    if ($this->getArgument('repo-call-sign') &&
-        $this->getArgument('repo-phid')) {
+    if ($repo_call_sign && $this->repositoryId) {
       echo pht(
         'Error: You cannot specify both --repo-call-sign and --repo-phid. '.
         'Please choose one or the other.'
@@ -139,7 +140,6 @@ EOTEXT
     }
 
     // if a call-sign is specified, look up the repository PHID
-    $repo_call_sign = $this->getArgument('repo-call-sign');
     if ($repo_call_sign) {
       $this->repositoryId =
           $this->getRepositoryPHIDFromCallSignConduit($repo_call_sign);
@@ -148,9 +148,6 @@ EOTEXT
                  $repo_call_sign);
         return 1;
       }
-    } else if ($this->getArgument('repo-phid')) {
-      // If the user specified a repo-phid, use that instead of the call-sign
-      $this->repositoryId = $this->getArgument('repo-phid');
     }
 
     // if a revision is not specified, get revision from the commit message
@@ -379,8 +376,11 @@ EOTEXT
     // remove text that says "No newline at end of file"
     $val = preg_replace('/^\\\ No newline at end of file$/m', '', $val);
 
-    // strip out all blank lines
-    $val = trim(preg_replace("/(^[\r\n]|[\r\n]+)/", "\n", $val));
+    // strip out consecutive blank lines
+    $val = preg_replace("/[\r\n]+/", "\n", $val);
+
+    // trim leading/trailing blank lines
+    $val = trim($val);
 
     return $val;
   }


### PR DESCRIPTION
 - fixing issue where a missing new line was resulting in false positives. 
 - fixed some random linter whitespace errors in other files. 