### PR TITLE
Add more practical examples to the arc call-conduit help output

### DIFF
--- a/src/workflow/ArcanistCallConduitWorkflow.php
+++ b/src/workflow/ArcanistCallConduitWorkflow.php
@@ -24,6 +24,7 @@ EOTEXT
             - Run this command from a working directory.
             - Call parameters are REQUIRED and read as a JSON blob from stdin.
             - Results are written to stdout as a JSON blob.
+            - Requires a valid Conduit API token set in ~/.arcrc (run `arc install-certificate` to get one)
 
           This workflow is primarily useful for writing scripts which integrate
           with Phabricator.

--- a/src/workflow/ArcanistCallConduitWorkflow.php
+++ b/src/workflow/ArcanistCallConduitWorkflow.php
@@ -57,13 +57,19 @@ EOTEXT
             Update Revision Accept:
             $ echo '{"transactions":[{"type":"accept","value":true}],"objectIdentifier":"PHID-DREV-sangdbezeh5nfeicqzeg"}' | arc call-conduit differential.revision.edit
 
-            Update Revision Projects (aka Tags):
+            Add Projects to Revision:
             $ echo '{"transactions":[{"type":"projects.add","value":["PHID-PROJ-u4i3446wedyolppkckbp"]}],"objectIdentifier":"PHID-DREV-zp4o4lfpsfwhnkglxln3"}' | arc call-conduit differential.revision.edit
+            
+            Remove Projects from Revision:
             $ echo '{"transactions":[{"type":"projects.remove","value":["PHID-PROJ-u4i3446wedyolppkckbp"]}],"objectIdentifier":"PHID-DREV-zp4o4lfpsfwhnkglxln3"}' | arc call-conduit differential.revision.edit
+            
+            Set Projects on Revision:
             $ echo '{"transactions":[{"type":"projects.set","value":["PHID-PROJ-u4i3446wedyolppkckbp"]}],"objectIdentifier":"PHID-DREV-zp4o4lfpsfwhnkglxln3"}' | arc call-conduit differential.revision.edit
 
-            Get Projects (aka Tags):
+            Get Revision's Projects (aka Tags):
             $ echo '{"constraints":{"ids":[13050281]},"attachments":{"projects":true}}' | arc call-conduit differential.revision.search
+            
+            Get Projects Details:
             $ echo '{"constraints":{"phids":["PHID-PROJ-u4i3446wedyolppkckbp"]}}' | arc call-conduit project.search
 
             Get Comments

--- a/src/workflow/ArcanistCallConduitWorkflow.php
+++ b/src/workflow/ArcanistCallConduitWorkflow.php
@@ -104,6 +104,9 @@ EOTEXT
 
             Get Repository:
             $ echo '{"constraints":{"phids":["PHID-REPO-uexvk77yeovy63fhokqw"]}}' | arc call-conduit diffusion.repository.search
+
+            Get Repository by Callsign:
+            $ echo '{"constraints":{"callsigns":["GOCODVJ"]}}' | arc call-conduit diffusion.repository.search
 EOTEXT
       );
   }

--- a/src/workflow/ArcanistCallConduitWorkflow.php
+++ b/src/workflow/ArcanistCallConduitWorkflow.php
@@ -34,10 +34,10 @@ EOTEXT
             Ping (check connectivity):
             $ echo '{}' | arc call-conduit conduit.ping
 
-            Get current user:
+            Get Current User:
             $ echo '{}' | arc call-conduit user.whoami
 
-            Get Users:
+            Get User Info:
             $ echo '{"constraints":{"usernames":["wua", "foo"]}}' | arc call-conduit user.search
 
             Search Revisions by ID:

--- a/src/workflow/ArcanistCallConduitWorkflow.php
+++ b/src/workflow/ArcanistCallConduitWorkflow.php
@@ -26,10 +26,78 @@ EOTEXT
             - Results are written to stdout as a JSON blob.
 
           This workflow is primarily useful for writing scripts which integrate
-          with Phabricator. Examples:
+          with Phabricator.
 
+          Examples:
+            
+            Ping (check connectivity):
             $ echo '{}' | arc call-conduit conduit.ping
-            $ echo '{"phid":"PHID-FILE-xxxx"}' | arc call-conduit file.download
+
+            Get current user:
+            echo '{}' | arc call-conduit user.whoami
+
+            Get Users:
+            $ echo '{"constraints":{"usernames":["wua", "foo"]}}' | arc call-conduit user.search
+
+            Search Revisions by ID:
+            $ echo '{"constraints":{"ids":[123,456,789]}}' | arc call-conduit differential.revision.search
+            
+            Search Revisions by PHID:
+            $ echo '{"constraints":{"phids":["PHID-DREV-wd4ovydtv4m5nsz6enax"]}}' | arc call-conduit differential.revision.search
+            
+            Search Revisions by User:
+            $ echo '{"constraints":{"authorPHIDs":["PHID-USER-g34zkv234n3rk3xlhgke"]}}' | arc call-conduit differential.revision.search
+
+            Update Revision Title:
+            $ echo '{"transactions":[{"type":"title","value":"my new title"}],"objectIdentifier":"PHID-DREV-zp4o4lfpsfwhnkglxln3"}' | arc call-conduit differential.revision.edit
+            
+            Update Revision Jira:
+            $ echo '{"transactions":[{"type":"uber-jira.issues","value":["CODE-204"]}],"objectIdentifier":"PHID-DREV-zp4o4lfpsfwhnkglxln3"}' | arc call-conduit differential.revision.edit
+            
+            Update Revision Accept:
+            $ echo '{"transactions":[{"type":"accept","value":true}],"objectIdentifier":"PHID-DREV-sangdbezeh5nfeicqzeg"}' | arc call-conduit differential.revision.edit
+
+            Update Revision Projects (aka Tags):
+            $ echo '{"transactions":[{"type":"projects.add","value":["PHID-PROJ-u4i3446wedyolppkckbp"]}],"objectIdentifier":"PHID-DREV-zp4o4lfpsfwhnkglxln3"}' | arc call-conduit differential.revision.edit
+            $ echo '{"transactions":[{"type":"projects.remove","value":["PHID-PROJ-u4i3446wedyolppkckbp"]}],"objectIdentifier":"PHID-DREV-zp4o4lfpsfwhnkglxln3"}' | arc call-conduit differential.revision.edit
+            $ echo '{"transactions":[{"type":"projects.set","value":["PHID-PROJ-u4i3446wedyolppkckbp"]}],"objectIdentifier":"PHID-DREV-zp4o4lfpsfwhnkglxln3"}' | arc call-conduit differential.revision.edit
+
+            Get Projects (aka Tags):
+            $ echo '{"constraints":{"ids":[13050281]},"attachments":{"projects":true}}' | arc call-conduit differential.revision.search
+            $ echo '{"constraints":{"phids":["PHID-PROJ-u4i3446wedyolppkckbp"]}}' | arc call-conduit project.search
+
+            Get Comments
+            $ echo '{"objectIdentifier":"D13050281"}' | arc call-conduit transaction.search
+            
+            Create General Comment
+            $ echo '{"revision_id":13050281,"message":"hi"}' | arc call-conduit differential.createcomment
+            
+            Create General Comment & Accept
+            $ echo '{"revision_id":13050281,"message":"a general comment!","action":"accept"}' | arc call-conduit differential.createcomment
+            
+            Create Inline Comment
+            $ echo '{"revisionID":13050281,"diffID":36482097,"filePath":"src/infra/devplatform/code-infra/code-review-ux/goo","isNewFile":true,"lineNumber":1,"content":"making an inline comment"}' | arc call-conduit differential.createinline
+
+            Create Inline Comment (threaded comment)
+            $ echo '{"revisionID":13050281,"diffID":36482097,"filePath":"src/infra/devplatform/code-infra/code-review-ux/goo","isNewFile":true,"lineNumber":1,"content":"making a comment thread","replyToCommentID":114219845}' | arc call-conduit differential.createinline
+
+            Get Buildable:
+            $ echo '{"constraints":{"containerPHIDs":["PHID-DREV-zp4o4lfpsfwhnkglxln3"]}}' | arc call-conduit harbormaster.buildable.search
+            
+            Get Build:
+            $ echo '{"constraints":{"buildables":["PHID-HMBB-qdryny55lxb5k3zjcpwr"]}}' | arc call-conduit harbormaster.build.search
+            
+            Get Build Targets:
+            $ echo '{"constraints":{"buildPHIDs":["PHID-HMBD-bx3g3fvgi62z5txlgnom"]},"order":"newest"}' | arc call-conduit harbormaster.target.search
+            
+            Get Build Target Logs:
+            $ echo '{"constraints":{"buildTargetPHIDs":["PHID-HMBT-cdnilgbxily6lmkss3oz"]},"order":"newest"}' | arc call-conduit harbormaster.log.search
+
+            Get File (returns file as base64-encoded string):
+            echo "{\"phid\":\"PHID-FILE-477xrgjyhhxd4qcurgtx\"}" | arc call-conduit file.download
+
+            Get Repository:
+            $ echo '{"constraints":{"phids":["PHID-REPO-uexvk77yeovy63fhokqw"]}}' | arc call-conduit diffusion.repository.search
 EOTEXT
       );
   }

--- a/src/workflow/ArcanistCallConduitWorkflow.php
+++ b/src/workflow/ArcanistCallConduitWorkflow.php
@@ -34,7 +34,7 @@ EOTEXT
             $ echo '{}' | arc call-conduit conduit.ping
 
             Get current user:
-            echo '{}' | arc call-conduit user.whoami
+            $ echo '{}' | arc call-conduit user.whoami
 
             Get Users:
             $ echo '{"constraints":{"usernames":["wua", "foo"]}}' | arc call-conduit user.search
@@ -94,7 +94,7 @@ EOTEXT
             $ echo '{"constraints":{"buildTargetPHIDs":["PHID-HMBT-cdnilgbxily6lmkss3oz"]},"order":"newest"}' | arc call-conduit harbormaster.log.search
 
             Get File (returns file as base64-encoded string):
-            echo "{\"phid\":\"PHID-FILE-477xrgjyhhxd4qcurgtx\"}" | arc call-conduit file.download
+            $ echo "{\"phid\":\"PHID-FILE-477xrgjyhhxd4qcurgtx\"}" | arc call-conduit file.download
 
             Get Repository:
             $ echo '{"constraints":{"phids":["PHID-REPO-uexvk77yeovy63fhokqw"]}}' | arc call-conduit diffusion.repository.search

--- a/src/workflow/ArcanistCallConduitWorkflow.php
+++ b/src/workflow/ArcanistCallConduitWorkflow.php
@@ -73,19 +73,19 @@ EOTEXT
             Get Projects Details:
             $ echo '{"constraints":{"phids":["PHID-PROJ-u4i3446wedyolppkckbp"]}}' | arc call-conduit project.search
 
-            Get Comments
+            Get Comments:
             $ echo '{"objectIdentifier":"D13050281"}' | arc call-conduit transaction.search
             
-            Create General Comment
+            Create General Comment:
             $ echo '{"revision_id":13050281,"message":"hi"}' | arc call-conduit differential.createcomment
             
-            Create General Comment & Accept
+            Create General Comment & Accept:
             $ echo '{"revision_id":13050281,"message":"a general comment!","action":"accept"}' | arc call-conduit differential.createcomment
             
-            Create Inline Comment
+            Create Inline Comment:
             $ echo '{"revisionID":13050281,"diffID":36482097,"filePath":"src/infra/devplatform/code-infra/code-review-ux/goo","isNewFile":true,"lineNumber":1,"content":"making an inline comment"}' | arc call-conduit differential.createinline
 
-            Create Inline Comment (threaded comment)
+            Create Inline Comment (threaded comment):
             $ echo '{"revisionID":13050281,"diffID":36482097,"filePath":"src/infra/devplatform/code-infra/code-review-ux/goo","isNewFile":true,"lineNumber":1,"content":"making a comment thread","replyToCommentID":114219845}' | arc call-conduit differential.createinline
 
             Get Buildable:


### PR DESCRIPTION
LLM agents currently struggle to figure out how to use `arc call-conduit` to interact with Phabricator APIs.

This adds useful examples to `arc call-conduit --help`, to help guide agents in tool usage.

## Test Plan
Ran `bin/arc call-conduit --help` and see expected output:

<img width="1408" height="914" alt="Screenshot 2025-07-15 at 10 06 07 AM" src="https://github.com/user-attachments/assets/96c309b1-a2a2-4e9d-828c-755bdc5bf649" />
