### PR TITLE
Add prompt for github beta users to increase friction

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -479,6 +479,9 @@ EOTEXT
     // Add a banner to inform users about GitHub invitation (after repo setup)
     $this->displayGitHubInvitationBanner();
 
+    // Add a banner to inform users about GitHub invitation (after repo setup)
+    $this->displayGitHubInvitationBanner();
+
     if ($this->getArgument('no-diff')) {
       $this->removeScratchFile('diff-result.json');
       $data = $this->runLintUnit();
@@ -756,7 +759,7 @@ EOTEXT
 
 EOBANNER;
 
-    $this->console->writeOut("<fg:green>%s</fg>\n", $banner);
+    $this->console->writeOut("<fg:green>%s</fg>", $banner);
     
     // Only show the prompt for new revisions (not when updating existing ones)
     // We need to check multiple conditions to determine the actual intent

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -468,9 +468,6 @@ EOTEXT
   public function run() {
     $this->console = PhutilConsole::getConsole();
 
-    // Add a banner to inform users about GitHub invitation
-    $this->displayGitHubInvitationBanner();
-
     // UBER CODE
     $this->uberRefProvider = new UberRefProvider(
       $this->getConfigurationManager()->getConfigFromAnySource('uber.arcanist.use_non_tag_refs', false)
@@ -478,6 +475,9 @@ EOTEXT
     // UBER CODE END
 
     $this->runRepositoryAPISetup();
+
+    // Add a banner to inform users about GitHub invitation (after repo setup)
+    $this->displayGitHubInvitationBanner();
 
     if ($this->getArgument('no-diff')) {
       $this->removeScratchFile('diff-result.json');
@@ -757,6 +757,94 @@ EOTEXT
 EOBANNER;
 
     $this->console->writeOut("<fg:green>%s</fg>\n", $banner);
+    
+    // Only show the prompt for new revisions (not when updating existing ones)
+    // We need to check multiple conditions to determine the actual intent
+    if ($this->shouldPromptForArh()) {
+      // Prompt user to consider using arh CLI tool instead
+      $prompt = pht(
+        'Would you like to create a GitHub PR instead?'
+      );
+      
+      if (phutil_console_confirm($prompt, $default_no = false)) {
+        $this->console->writeOut(
+          "%s\n%s\n%s\n%s\n\n%s\n",
+          pht('Great! You can create a GitHub PR using the arh CLI tool:'),
+          pht('  1. Ensure you are authenticated: %s', phutil_console_format('**arh auth**')),
+          pht('  2. Make your changes and commit them.'),
+          pht('  3. Publish your PR: %s', phutil_console_format('**arh publish**')),
+          pht('Documentation: %s', phutil_console_format('__%s__', 'https://p.uber.com/arh'))
+        );
+        throw new ArcanistUserAbortException();
+      }
+      
+      $this->console->writeOut(
+        "%s\n\n", 
+        pht('Continuing with Phabricator diff creation...')
+      );
+    }
+  }
+
+  /**
+   * Determine if we should prompt the user to use arh CLI tool.
+   * Only prompt for new revision creation, not updates or diff-only operations.
+   */
+  private function shouldPromptForArh() {
+    // Collect gating flags/conditions up front for clarity
+    $isCreate          = (bool)$this->getArgument('create');
+    $isUpdate          = (bool)$this->getArgument('update');
+    $isNoInteractive   = (bool)$this->getArgument('nointeractive');
+    $isTTY             = $this->isTTY();
+    $isJson            = (bool)$this->getArgument('json');
+    $isNoDiff          = (bool)$this->getArgument('no-diff');
+    $onlyCreateDiff    = (bool)$this->shouldOnlyCreateDiff();
+    $useCommitMessage  = (bool)$this->getArgument('use-commit-message');
+
+    // Single guard: skip prompting when any disqualifying condition is true
+    if (
+      $isNoInteractive ||
+      !$isTTY ||
+      $isJson ||
+      $isNoDiff ||
+      $isCreate ||
+      $isUpdate ||
+      $onlyCreateDiff ||
+      $useCommitMessage
+    ) {
+      return false;
+    }
+
+    // At this point, we need to check if Arcanist will auto-detect this
+    // as a new revision vs updating an existing one. We need to replicate
+    // the logic from buildCommitMessage() but without side effects.
+
+    try {
+      $repository_api = $this->getRepositoryAPI();
+      $revisions = $repository_api->loadWorkingCopyDifferentialRevisions(
+        $this->getConduit(),
+        array(
+          'authors' => array($this->getUserPHID()),
+          'status'  => 'status-open',
+        ));
+
+      // If no existing revisions found, this will be a new revision - prompt
+      if (!$revisions) {
+        return true;
+      }
+
+      // If exactly one revision found, this will be an update - don't prompt
+      if (count($revisions) == 1) {
+        return false;
+      }
+
+      // If multiple revisions, user will be asked to choose - this is ambiguous,
+      // so don't prompt for arh to avoid confusion
+      return false;
+
+    } catch (Exception $ex) {
+      // If we can't determine safely, don't prompt
+      return false;
+    }
   }
 
   private function runRepositoryAPISetup() {

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -479,9 +479,6 @@ EOTEXT
     // Add a banner to inform users about GitHub invitation (after repo setup)
     $this->displayGitHubInvitationBanner();
 
-    // Add a banner to inform users about GitHub invitation (after repo setup)
-    $this->displayGitHubInvitationBanner();
-
     if ($this->getArgument('no-diff')) {
       $this->removeScratchFile('diff-result.json');
       $data = $this->runLintUnit();
@@ -830,19 +827,8 @@ EOBANNER;
           'status'  => 'status-open',
         ));
 
-      // If no existing revisions found, this will be a new revision - prompt
-      if (!$revisions) {
-        return true;
-      }
-
-      // If exactly one revision found, this will be an update - don't prompt
-      if (count($revisions) == 1) {
-        return false;
-      }
-
-      // If multiple revisions, user will be asked to choose - this is ambiguous,
-      // so don't prompt for arh to avoid confusion
-      return false;
+      // Prompt only if no existing open revisions
+      return empty($revisions);
 
     } catch (Exception $ex) {
       // If we can't determine safely, don't prompt


### PR DESCRIPTION
### Overview
This change enhances `arc diff` with an interactive, default-Yes prompt encouraging users to create a GitHub PR using the `arh` CLI instead of a Phabricator diff, while being careful not to disrupt existing workflows or automation.

### What’s new
- Added a GitHub invitation banner and an opt-out prompt to use `arh` for PRs.
- The prompt defaults to Yes and provides brief instructions when accepted.

### Prompt conditions
The prompt only appears when all of the following are true:
- Interactive session: TTY is present and `--nointeractive` is not set
- Not machine output: `--json` is not set
- Not lint/unit only mode: `--no-diff` is not set
- Not explicitly chosen arc behavior:
  - Not `--create`
  - Not `--update`
  - Not `--use-commit-message`
- Not a diff-only path: `shouldOnlyCreateDiff()` is false
  - Covers `--preview`, `--only`, and raw (`--raw`/`--raw-command`) cases
- Repository-based detection indicates a new revision is likely:
  - No open revisions in the working copy → prompt
  - Exactly one open revision → skip (update path)
  - Multiple open revisions → skip (ambiguous; user chooses later)

### Behavioral details
- Default action: If user accepts, we show next steps for `arh` and exit cleanly.
- Continue with arc: If user declines, we print a brief message and proceed with Phabricator diff creation.
- Non-interactive/CI safety: No prompts in CI/non-TTY; JSON and internal `--no-diff` flows are preserved.

### Implementation notes
- Consolidated all gating checks into a single conditional for clarity and maintainability.
- Added repo-based fallback detection (mirrors `buildCommitMessage()` logic) to distinguish new vs update scenarios.
- Moved the banner/prompt call to after repository setup so repo/conduit are available before detection.

### Rationale
- Encourage migration to GitHub PRs without disrupting existing flows.
- Avoid breaking CI and scripts, and respect explicit user intent (create/update/commit-based flows).
- Ensure the prompt appears only when it is most helpful (new revision, interactive).

### Testing suggestions
- New change (should prompt): `arc diff`
<img width="687" height="406" alt="Screenshot 2025-08-11 at 5 21 26 PM" src="https://github.com/user-attachments/assets/97c01907-df23-47ad-a2c3-143bc049314b" />

- Update existing (no prompt): `arc diff --update D12345`
<img width="740" height="392" alt="Screenshot 2025-08-11 at 5 22 45 PM" src="https://github.com/user-attachments/assets/86b8bf80-ffa9-40c5-ae56-047f14300043" />

Same for flags below

- Commit-based (no prompt): `arc diff -C <commit>`
- Diff-only (no prompt): `arc diff --preview` or `arc diff --only` or `arc diff --raw`
- Automation (no prompt): `arc diff --nointeractive` or run in non-TTY
- JSON (no prompt): `arc diff --json`

- Moved prompt invocation after repo setup; confirmed no lints introduced.