### PR TITLE
[arcanist] Restrict arh prompt to only SQ-enabled repos

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -726,13 +726,18 @@ EOTEXT
 
   /**
    * Display a banner to inform users about GitHub.
-   * Display the banner for all users in the github-beta-users LDAP group,
-   * but only show the interactive prompt for repositories in the allowed list.
+   * Only display the banner and prompt if the user is in the github-beta-users LDAP group
+   * and the repository is in the allowed list.
    */
   private function displayGitHubInvitationBanner() {
     $gbu = new UberGitHubBetaUsers();
     $isMember = $gbu->isCurrentUserInGitHubBetaUsers();
     if (!$isMember) {
+      return;
+    }
+
+    // Check if current repository is in the allowed list for GitHub PR prompts
+    if (!$this->isRepositoryAllowedForGitHubPrompt()) {
       return;
     }
     
@@ -761,7 +766,7 @@ EOBANNER;
     
     // Only show the prompt for new revisions (not when updating existing ones)
     // We need to check multiple conditions to determine the actual intent
-    if ($this->shouldPromptForArh() && $this->isRepositoryAllowedForGitHubPrompt()) {
+    if ($this->shouldPromptForArh()) {
       // Prompt user to consider using arh CLI tool instead
       $prompt = pht(
         'Would you like to create a GitHub PR instead?'
@@ -787,8 +792,7 @@ EOBANNER;
   }
 
   /**
-   * Check if the current repository is allowed for the GitHub PR interactive prompt.
-   * Note: This only restricts the prompt, not the informational banner.
+   * Check if the current repository is allowed for GitHub banner and prompt.
    * @return bool True if the repository is in the allowed list, false otherwise.
    */
   private function isRepositoryAllowedForGitHubPrompt() {

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -726,7 +726,8 @@ EOTEXT
 
   /**
    * Display a banner to inform users about GitHub.
-   * Only display the banner if the user is in the github-beta-users LDAP group.
+   * Display the banner for all users in the github-beta-users LDAP group,
+   * but only show the interactive prompt for repositories in the allowed list.
    */
   private function displayGitHubInvitationBanner() {
     $gbu = new UberGitHubBetaUsers();
@@ -760,7 +761,7 @@ EOBANNER;
     
     // Only show the prompt for new revisions (not when updating existing ones)
     // We need to check multiple conditions to determine the actual intent
-    if ($this->shouldPromptForArh()) {
+    if ($this->shouldPromptForArh() && $this->isRepositoryAllowedForGitHubPrompt()) {
       // Prompt user to consider using arh CLI tool instead
       $prompt = pht(
         'Would you like to create a GitHub PR instead?'
@@ -783,6 +784,44 @@ EOBANNER;
         pht('Continuing with Phabricator diff creation...')
       );
     }
+  }
+
+  /**
+   * Check if the current repository is allowed for the GitHub PR interactive prompt.
+   * Note: This only restricts the prompt, not the informational banner.
+   * @return bool True if the repository is in the allowed list, false otherwise.
+   */
+  private function isRepositoryAllowedForGitHubPrompt() {
+    $allowed_repos = array(
+      'go-code',
+      'web-code',
+      'lm/fievel',
+      'mobile/android',
+      'mobile/ios',
+      'uber-one',
+      'data/ml-code',
+      'data/authored-schemas',
+      'finance/banker-rules',
+      'devexp/devpod-monorepo',
+      'rt/edge-gateway',
+      'devexp/failover-test-repo',
+      'data/hoodie_oss',
+      'sre/rdp-config',
+      'rt/realtime-api',
+      'infra/statsdex',
+      'usecurity/uspecs',
+      'mobile/dummy_repo_1',
+      'mobile/dummy_repo_3',
+      'infra/config-test',
+      'testing/submitqueue-e2e',
+    );
+
+    $repo_name = $this->getRepositoryName();
+    if ($repo_name === null) {
+      return false;
+    }
+
+    return in_array($repo_name, $allowed_repos);
   }
 
   /**


### PR DESCRIPTION
We want to restrict the banner + prompting to only SQ-enabled repos since all other microrepos are not fully supported yet and we don't want to inform users in those repos.

GitHub Repository Name | Gitolite Repository Name
-- | --
uber-code/go-code | go-code
uber-code/web-code | web-code
uber-code/java-code | lm/fievel
uber-code/android-code | mobile/android
uber-code/ios-code | mobile/ios
uber-code/uber-one | uber-one
uber-code/data-ml-code | data/ml-code
uber-code/data-authored-schemas | data/authored-schemas
uber-code/finance-banker-rules | finance/banker-rules
uber-code/devexp-devpod-monorepo | devexp/devpod-monorepo
uber-code/rt-edge-gateway | rt/edge-gateway
uber-code/devexp-failover-test-repo | devexp/failover-test-repo
uber-code/data-hoodie_oss | data/hoodie_oss
uber-code/sre-rdp-config | sre/rdp-config
uber-code/rt-realtime-api | rt/realtime-api
uber-code/infra-statsdex | infra/statsdex
uber-code/usecurity-uspecs | usecurity/uspecs
uber-code/mobile-dummy_repo_1 | mobile/dummy_repo_1
uber-code/mobile-dummy_repo_3 | mobile/dummy_repo_3
uber-code/infra-config-test | infra/config-test
uber-code-staging/submitqueue-e2e | testing/submitqueue-e2e



### non-SQ enabled repo doesn't prompt anymore:
<img width="751" height="70" alt="Screenshot 2025-08-15 at 1 00 16 PM" src="https://github.com/user-attachments/assets/b686089e-9ba4-4d98-82a0-15d3e6631f46" />

### SQ enabled repo does prompt still:
<img width="904" height="325" alt="Screenshot 2025-08-15 at 12 59 26 PM" src="https://github.com/user-attachments/assets/aeeb120e-d687-4b56-a977-a15bbc136296" />

