### PR TITLE
Base ref fetch bug fix

### DIFF
--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -1381,7 +1381,7 @@ EOTEXT
 
     // Fetch the base ref of diff
     echo pht('Fetching base ref "%s" from staging remote', $base_ref)."\n";
-    $err = $repository_api->execPassthru('fetch --no-tags %s %s:%s', $staging_uri, $base_ref, $base_ref);
+    $err = $repository_api->execPassthru('fetch --no-tags %s +%s:%s', $staging_uri, $base_ref, $base_ref);
     if ($err) {
       throw new ArcanistUsageException(pht('Failed to fetch base ref "%s" from staging area', $base_ref));
     }

--- a/src/workflow/ArcanistPatchWorkflow.php
+++ b/src/workflow/ArcanistPatchWorkflow.php
@@ -1381,7 +1381,7 @@ EOTEXT
 
     // Fetch the base ref of diff
     echo pht('Fetching base ref "%s" from staging remote', $base_ref)."\n";
-    $err = $repository_api->execPassthru('fetch --no-tags %s %s', $staging_uri, $base_ref);
+    $err = $repository_api->execPassthru('fetch --no-tags %s %s:%s', $staging_uri, $base_ref, $base_ref);
     if ($err) {
       throw new ArcanistUsageException(pht('Failed to fetch base ref "%s" from staging area', $base_ref));
     }

--- a/src/workflow/__tests__/ArcanistPatchWorkflowTestCase.php
+++ b/src/workflow/__tests__/ArcanistPatchWorkflowTestCase.php
@@ -96,7 +96,7 @@ final class ArcanistPatchWorkflowTestCase extends PhutilTestCase {
       }
 
       public function execPassthru($command, $args) {
-        if ($command === 'fetch --no-tags %s %s') {
+        if ($command === 'fetch --no-tags %s %s:%s') {
           return $this->options['fetch_success'] ? 0 : 1;
         }
         throw new Exception("Unexpected execPassthru command: '$command'");

--- a/src/workflow/__tests__/ArcanistPatchWorkflowTestCase.php
+++ b/src/workflow/__tests__/ArcanistPatchWorkflowTestCase.php
@@ -96,7 +96,7 @@ final class ArcanistPatchWorkflowTestCase extends PhutilTestCase {
       }
 
       public function execPassthru($command, $args) {
-        if ($command === 'fetch --no-tags %s %s:%s') {
+        if ($command === 'fetch --no-tags %s +%s:%s') {
           return $this->options['fetch_success'] ? 0 : 1;
         }
         throw new Exception("Unexpected execPassthru command: '$command'");


### PR DESCRIPTION
## Summary
Fixing a bug in the fetch for the base ref in the `arc patch --uber-merge-using-staging-tag` validation. We were previously fetching the base ref, but not saving it to a local ref. This was causing an error when calculating the merge-base with main, which allowed `[preserve-git-history]` commits to be merged when their base did not exist on main.
## Test Plan
Tested locally with the same test cases described in the original [PR](https://github.com/uber/arcanist/pull/307).

[Bad diff](https://code.uberinternal.com/D18914417)
<img width="1040" height="474" alt="image" src="https://github.com/user-attachments/assets/6db47165-798d-42a6-9ce2-3a29f860743f" />

[Good diff](https://code.uberinternal.com/D18915841)
<img width="736" height="416" alt="image" src="https://github.com/user-attachments/assets/f566b995-24d8-47a0-847c-c589201ca4f0" />

[Microrepo -> monorepo migration diff](https://code.uberinternal.com/D18767285)
<img width="735" height="409" alt="image" src="https://github.com/user-attachments/assets/70ed7fbe-8613-4fcb-aad8-50acc81d9998" />
