### PR TITLE
[arcanist] Remove SubmitQueue repo filtering

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -735,11 +735,6 @@ EOTEXT
     if (!$isMember) {
       return;
     }
-
-    // Check if current repository is in the allowed list for GitHub PR prompts
-    if (!$this->isRepositoryAllowedForGitHubPrompt()) {
-      return;
-    }
     
     $docs_link = "\033]8;;https://p.uber.com/arh\033\\p.uber.com/arh\033]8;;\033\\";
     $slack_link = "\033]8;;https://uber.enterprise.slack.com/archives/C05H81RFE4F\033\\#github-pr-beta\033]8;;\033\\";
@@ -789,43 +784,6 @@ EOBANNER;
         pht('Continuing with Phabricator diff creation...')
       );
     }
-  }
-
-  /**
-   * Check if the current repository is allowed for GitHub banner and prompt.
-   * @return bool True if the repository is in the allowed list, false otherwise.
-   */
-  private function isRepositoryAllowedForGitHubPrompt() {
-    $allowed_repos = array(
-      'go-code',
-      'web-code',
-      'lm/fievel',
-      'mobile/android',
-      'mobile/ios',
-      'uber-one',
-      'data/ml-code',
-      'data/authored-schemas',
-      'finance/banker-rules',
-      'devexp/devpod-monorepo',
-      'rt/edge-gateway',
-      'devexp/failover-test-repo',
-      'data/hoodie_oss',
-      'sre/rdp-config',
-      'rt/realtime-api',
-      'infra/statsdex',
-      'usecurity/uspecs',
-      'mobile/dummy_repo_1',
-      'mobile/dummy_repo_3',
-      'infra/config-test',
-      'testing/submitqueue-e2e',
-    );
-
-    $repo_name = $this->getRepositoryName();
-    if ($repo_name === null) {
-      return false;
-    }
-
-    return in_array($repo_name, $allowed_repos);
   }
 
   /**

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -798,23 +798,6 @@ EOBANNER;
   private function isRepositoryDisabledForGitHubPrompt() {
     $denied_repos = array(
       // These are repos that are disabled because of vref checks, more info: https://t.uber.com/blocked-vref-repos
-      'config/client-go',
-      'config/flip-go',
-      'config/flipr-core',
-      'config/ucs-validation',
-      'connect-cookies',
-      'data/uworc-workflows',
-      'data/uworc-workflows-staging',
-      'engsec/breeze',
-      'engsec/galileo-java',
-      'engsec/sri-phantom-apps',
-      'engsec/sri-phantom-playbooks',
-      'engsec/sri-phantom-utils',
-      'engsec/wonka-java',
-      'inuit.css',
-      'marketplace/fulfillment',
-      'mirroring_test',
-      'web-tools',
       'infra/config',
       'infra/config-staging',
       'engsec/infra-as-code',

--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -726,13 +726,18 @@ EOTEXT
 
   /**
    * Display a banner to inform users about GitHub.
-   * Only display the banner and prompt if the user is in the github-beta-users LDAP group
-   * and the repository is in the allowed list.
+   * Only display the banner and prompt if the user is in the github-beta-users-prompt LDAP group
+   * and the repository is not in the deny list.
    */
   private function displayGitHubInvitationBanner() {
     $gbu = new UberGitHubBetaUsersPrompt();
     $isMember = $gbu->isCurrentUserInGitHubBetaUsersPromptGroup();
     if (!$isMember) {
+      return;
+    }
+
+    // Check if current repository is in the deny list for GitHub PR prompts
+    if ($this->isRepositoryDisabledForGitHubPrompt()) {
       return;
     }
     
@@ -784,6 +789,57 @@ EOBANNER;
         pht('Continuing with Phabricator diff creation...')
       );
     }
+  }
+
+  /**
+   * Check if the current repository is disabled for GitHub banner and prompt.
+   * @return bool True if the repository is in the deny list, false otherwise.
+   */
+  private function isRepositoryDisabledForGitHubPrompt() {
+    $denied_repos = array(
+      // These are repos that are disabled because of vref checks, more info: https://t.uber.com/blocked-vref-repos
+      'config/client-go',
+      'config/flip-go',
+      'config/flipr-core',
+      'config/ucs-validation',
+      'connect-cookies',
+      'data/uworc-workflows',
+      'data/uworc-workflows-staging',
+      'engsec/breeze',
+      'engsec/galileo-java',
+      'engsec/sri-phantom-apps',
+      'engsec/sri-phantom-playbooks',
+      'engsec/sri-phantom-utils',
+      'engsec/wonka-java',
+      'inuit.css',
+      'marketplace/fulfillment',
+      'mirroring_test',
+      'web-tools',
+      'infra/config',
+      'infra/config-staging',
+      'engsec/infra-as-code',
+      'rt/idl-registry',
+
+      // These are other unsupported repos
+      "mobile/ios", // iOS visual snapshots not supported yet
+    );
+
+    $repo_name = $this->getRepositoryName();
+    if ($repo_name === null) {
+      return false;
+    }
+
+    // Check if repo is in the explicit deny list
+    if (in_array($repo_name, $denied_repos)) {
+      return true;
+    }
+
+    // Check if repo starts with "objectconfig/"
+    if (strpos($repo_name, 'objectconfig/') === 0) {
+      return true;
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
## Summary

We had added filtering previously to only show the banner+prompt for SubmitQueue repos since other microrepos did not have appropriate perms set. 

This has now been fixed with the PlatEng rollout so we have decided to remove this filtering and show this banner+prompt to all PlatEng members for all repos. 

The repos that are not supported and are the caveats/exceptions are mentioned in the banner link: https://p.uber.com/arh

## Test Plan

Running `arc diff` for non-submitqueue repo shows banner+prompt
<img width="523" height="286" alt="Screenshot 2025-10-07 at 1 11 47 PM" src="https://github.com/user-attachments/assets/7f182910-bc4e-4b57-ba5f-e33e0538875b" />
