### PR TITLE
[arcanist] Fix objectconfig exemption from access reduction

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -924,17 +924,15 @@ EOBANNER;
     );
 
     $repo_name = $this->getRepositoryName();
+    
+    // If repo is not in Phabricator, don't block
+    // This exempts objectconfig repos that are not registered in Phabricator
     if ($repo_name === null) {
-      return false;
+      return true;
     }
 
     // Check if repo is in the explicit deny list
     if (in_array($repo_name, $denied_repos)) {
-      return true;
-    }
-
-    // Check if repo starts with "objectconfig/"
-    if (strpos($repo_name, 'objectconfig/') === 0) {
       return true;
     }
 


### PR DESCRIPTION
## Summary

Objectconfig repos were still getting access reduction blocking behavior, despite there being an exception.

This is because the `GetRepository()` call returns NULL for non`uber-code` repos, and thus were still getting blocked.

This change updates the logic to fail gracefully and not block for any empty response
(i.e. non uber-code orgs, including objectconfig, objectconfig-staging, etc.)

## Test Plan
Verified that infra/config and other repos that aren't supported in GitHub are functioning as expected.

arc diff doesn't block in objectconfig anymore:
<img width="573" height="104" alt="Screenshot 2025-10-29 at 9 05 18 AM" src="https://github.com/user-attachments/assets/c8c20776-7e9a-4ceb-b781-d400af38aa2d" />

