### PR TITLE
[arcanist] Fix objectconfig blocking behavior

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -926,13 +926,18 @@ EOBANNER;
     $repo_name = $this->getRepositoryName();
     
     // If repo is not in Phabricator, don't block
-    // This exempts objectconfig repos that are not registered in Phabricator
+    // This exempts any repos that are not registered in Phabricator
     if ($repo_name === null) {
       return true;
     }
 
     // Check if repo is in the explicit deny list
     if (in_array($repo_name, $denied_repos)) {
+      return true;
+    }
+
+    // Check if repo starts with "objectconfig/"
+    if (strpos($repo_name, 'objectconfig/') === 0) {
       return true;
     }
 


### PR DESCRIPTION
Previously we had removed the condition to block on objectconfig repos because of the assumption that all of them would return null for repository.query.
This is not true because the query works for config.uber.internal remotes and not code.uber.internal remotes.

Thus, adding this condition back should fix the issue.

## Test Plan

repository.query works when using correct remote: config.uber.internal
<img width="1753" height="123" alt="Screenshot 2025-11-13 at 1 20 53 PM" src="https://github.com/user-attachments/assets/b00834ee-00d1-4f07-ac61-c1092145a569" />
