### PR TITLE
[arcanist] Add Content-Length header to SQ POST request

### DIFF
--- a/src/land/UberSubmitQueueClient.php
+++ b/src/land/UberSubmitQueueClient.php
@@ -79,6 +79,14 @@ final class UberSubmitQueueClient extends Phobject {
         $core_future->addHeader('Authorization', "Bearer {$token}");
 
         $core_future->setMethod($method);
+
+        // For POST requests, explicitly set Content-Length header (even if 0)
+        // This is required by GCP frontend to avoid 411 errors
+        // Setting this AFTER setMethod() ensures it's not overridden
+        if (strtoupper($method) === 'POST') {
+          $core_future->addHeader('Content-Length', '0');
+        }
+        
         $core_future->setTimeout($this->timeout);
 
         $json_future = new UberSubmitQueueFuture($core_future);


### PR DESCRIPTION
## Summary
We are adding the Content-Length header to all POST requests sent to submitqueue via arc (i.e. arc land/arc stack)

This is because the recent GCP migration due to the Cloudflare outage started causing failures for the arc commands above with the error shown below. This is a mitigation effort for https://incidents.uberinternal.com/incident/f0344bfd-2886-4f51-b72d-747888623e8b

## Test Plan
### Before

<img width="977" height="512" alt="Screenshot 2025-11-18 at 2 31 56 PM" src="https://github.com/user-attachments/assets/14521eff-2e66-4cc5-acae-c57f24b7e513" />

### After
<img width="1800" height="886" alt="Screenshot 2025-11-18 at 2 33 22 PM" src="https://github.com/user-attachments/assets/09cdc6c2-c1ce-4319-9523-bc7fbdab2632" />

### Priority Request still work

## Jira Issues
https://t3.uberinternal.com/browse/CODE-4207