### PR TITLE
[arcanist] Add Librelease Path Exemption for GitHub PR Blocking

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -782,6 +782,11 @@ EOTEXT
       return;
     }
 
+    // Skip if any changed files are under librelease paths
+    if ($this->areAnyChangedFilesUnderLibreleasePaths()) {
+      return;
+    }
+
     // Block diff creation and show GitHub PR instructions
     $this->console->writeOut(
       "%s\n%s\n%s\n\n%s\n%s\n%s\n%s\n\n%s\n\n%s\n",
@@ -942,6 +947,72 @@ EOBANNER;
     }
 
     return false;
+  }
+
+  /**
+   * Check if any changed files in the diff are under librelease paths.
+   * Reads configuration from LibReleaseTestEngine in unit.engine.multi.engines.
+   * If any file is under a librelease path, we skip the GitHub PR blocking behavior.
+   * @return bool True if any changed file is under a librelease path, false otherwise.
+   */
+  private function areAnyChangedFilesUnderLibreleasePaths() {
+    try {
+      // Get librelease paths configuration from LibReleaseTestEngine in .arcconfig
+      $librelease_config = null;
+      
+      $engines_config = $this->getConfigurationManager()
+        ->getConfigFromAnySource('unit.engine.multi.engines');
+      
+      if (!empty($engines_config) && is_array($engines_config)) {
+        foreach ($engines_config as $engine_config) {
+          if (isset($engine_config['engine']) && 
+              $engine_config['engine'] === 'LibReleaseTestEngine') {
+            
+            if (isset($engine_config['uber.librelease.paths'])) {
+              $librelease_config = $engine_config['uber.librelease.paths'];
+            }
+            
+            break;
+          }
+        }
+      }
+      
+      if (empty($librelease_config)) {
+        // No librelease paths configured, don't skip blocking
+        return false;
+      }
+
+      // Get changed files from the repository
+      $repository_api = $this->getRepositoryAPI();
+      $changed_paths = $repository_api->getWorkingCopyStatus();
+      
+      if (empty($changed_paths)) {
+        // No changed files, don't skip blocking
+        return false;
+      }
+
+      // Check if any changed file is under a librelease path
+      foreach ($changed_paths as $path => $mask) {
+        // Skip untracked files
+        if ($mask & ArcanistRepositoryAPI::FLAG_UNTRACKED) {
+          continue;
+        }
+
+        // Check if the path matches any librelease path prefix
+        foreach ($librelease_config as $librelease_prefix => $library_name) {
+          if (strpos($path, $librelease_prefix) === 0) {
+            // Found at least one file under a librelease path, skip blocking
+            return true;
+          }
+        }
+      }
+
+      // No files found under librelease paths, don't skip blocking
+      return false;
+    } catch (Exception $ex) {
+      // If anything goes wrong, don't skip blocking (safer to block)
+      return false;
+    }
   }
 
 


### PR DESCRIPTION
## Summary
Skip GitHub PR blocking in `arc diff` when any changed files touch librelease paths.

## Problem
Library maintenance teams working on librelease code need to continue using Phabricator diffs. The current GitHub PR blocking forces them to use `--force` with exemption reasons, creating unnecessary friction for legitimate librelease work.

## Solution
Added `areAnyChangedFilesUnderLibreleasePaths()` method that:
1. Reads `uber.librelease.paths` from `LibReleaseTestEngine` configuration in `.arcconfig`
2. Checks if **ANY** changed file starts with a configured librelease path prefix
3. Skips GitHub PR blocking if at least one librelease file is touched

**Matching logic**: Simple prefix check - returns `true` as soon as one librelease file is found

## Configuration
Uses existing `LibReleaseTestEngine` configuration:
```
{
  "unit.engine.multi.engines": [
    {
      "engine": "LibReleaseTestEngine",
      "uber.librelease.paths": {
        "src/code.uber.internal/devexp/librelease/": "librelease",
        "src/code.uber.internal/glue/framework.git/": "fx",
        "third_party/go.uber.org/fx/": "fx"
      }
    }
  ]
}
```

### Behavior
✅ Any file in librelease paths → No blocking
⚠️ All files outside librelease paths → Normal blocking

## Testing
Tested in go-code monorepo (GOCODVJ) with LibReleaseTestEngine configured.
<img width="1331" height="598" alt="Screenshot 2025-12-10 at 9 57 06 AM" src="https://github.com/user-attachments/assets/161b89d6-0885-4915-ab6b-3116a5894f45" />
