### PR TITLE
[arcanist] Read uber.librelease.paths from top-level

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -951,28 +951,35 @@ EOBANNER;
 
   /**
    * Check if any changed files in the diff are under librelease paths.
-   * Reads configuration from LibReleaseTestEngine in unit.engine.multi.engines.
+   * Reads uber.librelease.paths from either:
+   *   1. Top-level .arcconfig, or
+   *   2. LibReleaseTestEngine in unit.engine.multi.engines
    * If any file is under a librelease path, we skip the GitHub PR blocking behavior.
    * @return bool True if any changed file is under a librelease path, false otherwise.
    */
   private function areAnyChangedFilesUnderLibreleasePaths() {
     try {
-      // Get librelease paths configuration from LibReleaseTestEngine in .arcconfig
-      $librelease_config = null;
+      // Get librelease paths configuration from .arcconfig
+      // First try top-level config
+      $librelease_config = $this->getConfigurationManager()
+        ->getConfigFromAnySource('uber.librelease.paths');
       
-      $engines_config = $this->getConfigurationManager()
-        ->getConfigFromAnySource('unit.engine.multi.engines');
-      
-      if (!empty($engines_config) && is_array($engines_config)) {
-        foreach ($engines_config as $engine_config) {
-          if (isset($engine_config['engine']) && 
-              $engine_config['engine'] === 'LibReleaseTestEngine') {
-            
-            if (isset($engine_config['uber.librelease.paths'])) {
-              $librelease_config = $engine_config['uber.librelease.paths'];
+      // If not found at top level, try to find it in LibReleaseTestEngine config
+      if (empty($librelease_config)) {
+        $engines_config = $this->getConfigurationManager()
+          ->getConfigFromAnySource('unit.engine.multi.engines');
+        
+        if (!empty($engines_config) && is_array($engines_config)) {
+          foreach ($engines_config as $engine_config) {
+            if (isset($engine_config['engine']) && 
+                $engine_config['engine'] === 'LibReleaseTestEngine') {
+              
+              if (isset($engine_config['uber.librelease.paths'])) {
+                $librelease_config = $engine_config['uber.librelease.paths'];
+              }
+              
+              break;
             }
-            
-            break;
           }
         }
       }


### PR DESCRIPTION
## Summary

There was a change made to the .arcconfigs in monorepos where librelease.paths were moved to the top-level instead of under the `LibReleaseTestEngine`. This broke our logic to unblock `arc diff` for librelease changes.

Example change: https://sg.uberinternal.com/code.uber.internal/uber-code/java-code/-/commit/2c3a0a3f308f3fe0cc7f7f7b2d7f739406abda4c

Thus we are reading the paths from the top-level as well now.

## Test Plan
Librelease change is blocked without these changees -> with these changes it is unblocked.
<img width="1218" height="533" alt="Screenshot 2026-01-22 at 6 52 46 PM" src="https://github.com/user-attachments/assets/a8f7f1b9-b7dd-4573-a032-712016a6db6b" />
