### PR TITLE
[arcanist] Add --auto-request-review flag to arc diff

### DIFF
--- a/src/workflow/ArcanistDiffWorkflow.php
+++ b/src/workflow/ArcanistDiffWorkflow.php
@@ -23,6 +23,7 @@ final class ArcanistDiffWorkflow extends ArcanistDiffBasedWorkflow {
   private $hitAutotargets;
   private $uberRefProvider; // UBER CODE
   private $autolandProjectPhid = 'PHID-PROJ-u4i3446wedyolppkckbp'; // UBER CODE
+  private $autoRequestReviewProjectPhid = 'PHID-PROJ-vkcf4mjefnjshq37izot'; // UBER CODE
 
   public function getWorkflowName() {
     return 'diff';
@@ -199,6 +200,9 @@ EOTEXT
       ),
       'noautoland' => array(
         'help' => pht('Do not autoland this change (Skips interactive prompt)'),
+      ),
+      'auto-request-review' => array(
+        'help' => pht('Tag this revision with the AutoRequestReview project on creation and update.'),
       ),
       'nolint' => array(
         'help' => pht('Do not run lint.'),
@@ -708,6 +712,16 @@ EOTEXT
             'objectIdentifier' => $result['revisionid'],
             'transactions' => array(
               array('type' => 'projects.add', 'value' => array($this->autolandProjectPhid)),
+            ),
+        ));
+      }
+
+      if ($this->getArgument('auto-request-review')) {
+        $conduit->callMethodSynchronous('differential.revision.edit',
+          array(
+            'objectIdentifier' => $result['revisionid'],
+            'transactions' => array(
+              array('type' => 'projects.add', 'value' => array($this->autoRequestReviewProjectPhid)),
             ),
         ));
       }


### PR DESCRIPTION
## Summary

- Adds \`--auto-request-review\` flag to \`arc diff\` that tags the Phabricator revision with the \`AutoRequestReview\` project on both creation and update
- Tags are applied via \`differential.revision.edit\` with a \`projects.add\` transaction (same mechanism as the existing \`--autoland\` flag)
- Linear issue: https://linear.app/uber/issue/CODER-432

## Test plan
- [ ] Run \`arc diff --auto-request-review\` on a new diff and verify the AutoRequestReview project tag appears on the Phabricator revision
- [ ] Run \`arc diff --auto-request-review\` on an existing revision (update) and verify the tag is applied on update too

🤖 Generated with [Claude Code](https://claude.ai/claude-code)